### PR TITLE
Fix issue #20 and #23

### DIFF
--- a/src/components/dashboard/dashboard.component.html
+++ b/src/components/dashboard/dashboard.component.html
@@ -3,7 +3,7 @@
   <app-preference-group title="Audification" [subject]="audification.enabled">
     <app-preference-item name="Lowest note (Hz)" [subject]="audification.lowestPitch"></app-preference-item>
     <app-preference-item name="Highest note (Hz)" [subject]="audification.highestPitch"></app-preference-item>
-    <app-preference-item name="Note duration (sec)" [subject]="audification.noteDuration"></app-preference-item>
+    <app-preference-item name="Note duration (ms)" [subject]="audification.noteDuration"></app-preference-item>
     <app-preference-item name="Read out before playing" [subject]="audification.readBefore"></app-preference-item>
     <app-preference-item name="Read out after playing" [subject]="audification.readAfter"></app-preference-item>
   </app-preference-group>

--- a/src/components/line-chart-audification/line-chart-audification.component.ts
+++ b/src/components/line-chart-audification/line-chart-audification.component.ts
@@ -27,6 +27,7 @@ export class LineChartAudificationComponent implements AudificationPreference, O
   private domain: Date[];
   private range: number[];
   @HostBinding('attr.tabindex') private readonly tabindex = 0;
+  private readOutTimeoutId: number | null = null;
 
   constructor(
     @Inject('host') private host: LineChartComponent,
@@ -73,19 +74,10 @@ export class LineChartAudificationComponent implements AudificationPreference, O
     this.melody?.dispose();
   }
 
-  handleSeek(index, playing) {
-    const datum = this.data[index];
-    const { date, value } = datum;
-
+  handleSeek(index) {
     // since Tone.js is running outside of the Angular zone, it needs to reenter the zone to trigger change detection.
     this.zone.run((() => {
-      this.activeDatum = datum;
-      if (!playing) {
-        this.readOut(t(AUDIFICATION.ACTIVE_DATUM, {
-          x: formatX(date),
-          y: formatY(value),
-        }));
-      }
+      this.activeDatum = this.data[index];
     }));
   }
 
@@ -94,11 +86,11 @@ export class LineChartAudificationComponent implements AudificationPreference, O
     $event.preventDefault();
     $event.stopPropagation();
     const { key, shiftKey, repeat } = $event;
-    if (repeat) {
+    if (!this.melody || repeat) {
       return;
     }
     if (key === ' ') {
-      await this.melody?.resume(shiftKey);
+      await this.melody.resume(shiftKey);
     } else if (key === 'x') {
       this.readOut(t(AUDIFICATION.DOMAIN, {
         min: formatX(this.domain[0]),
@@ -112,17 +104,23 @@ export class LineChartAudificationComponent implements AudificationPreference, O
     } else if (key === 'l') {
       this.readOut(humanizeMeasureName(this.measureName));
     } else if ('0' <= key && key <= '9') {
-      this.melody?.seekTo(this.melody.duration * (+key / 10), true);
+      const datumIndex = Math.floor(+key / 10 * this.data.length);
+      this.melody.seekTo(datumIndex, true);
+      this.readOutCurrentDatum();
     }
   }
 
   @HostListener('keyup', ['$event'])
   handleKeyUp($event: KeyboardEvent) {
+    if (!this.melody) {
+      return;
+    }
     $event.preventDefault();
     $event.stopPropagation();
     const { key } = $event;
     if (key === ' ') {
-      this.melody?.pause();
+      this.melody.pause();
+      this.readOutCurrentDatum();
     }
   }
 
@@ -132,13 +130,29 @@ export class LineChartAudificationComponent implements AudificationPreference, O
   }
 
   private readOut(text: string) {
+    if (this.readOutTimeoutId !== null) {
+      window.clearTimeout(this.readOutTimeoutId);
+      this.readOutTimeoutId = null;
+    }
     if (this.liveText === text) {
       this.liveText = null; // empty the text for a short period of time when the same text needs to be read out consequently
-      window.setTimeout(() => {
+      this.readOutTimeoutId = window.setTimeout(() => {
+        this.readOutTimeoutId = null;
         this.readOut(text);
       }, 500);
     } else {
       this.liveText = text;
     }
+  }
+
+  private readOutCurrentDatum() {
+    if (!this.melody) {
+      return;
+    }
+    const { date, value } = this.data[this.melody.currentDatumIndex];
+    this.readOut(t(AUDIFICATION.ACTIVE_DATUM, {
+      x: formatX(date),
+      y: formatY(value),
+    }));
   }
 }

--- a/src/models/melody/melody.model.spec.ts
+++ b/src/models/melody/melody.model.spec.ts
@@ -18,7 +18,6 @@ describe('Melody', () => {
 
   afterEach(() => {
     melody.dispose();
-    Tone.Transport.stop();
   });
 
   it('should instantiate.', () => {

--- a/src/models/melody/melody.model.spec.ts
+++ b/src/models/melody/melody.model.spec.ts
@@ -4,11 +4,13 @@ import * as Tone from 'tone';
 describe('Melody', () => {
   const values = [1, 2, 3, 4, 5, 4, 3, 2, 1];
   const frequencyRange: [number, number] = [256, 2048];
-  const noteDuration = 0.1; // duration (in seconds) of a note
+  const noteDuration = 100; // duration (in ms) of a note
   let melody: Melody;
-  const delay = 200; // delay (in ms) between playing the melody and evaluating playhead
+  const delay = noteDuration * 1.5; // delay (in ms) between playing the melody and evaluating playhead
+  const gracePeriod = 200; // grace period (in ms) before Tone.js can start without errors
 
   beforeAll(async () => {
+    await new Promise(resolve => window.setTimeout(resolve, gracePeriod));
     await Tone.start();
   });
 
@@ -29,7 +31,7 @@ describe('Melody', () => {
   });
 
   it('should have playhead at the very beginning of the sequence', () => {
-    expect(melody.currentSeconds).toBeCloseTo(0, 1e-3);
+    expect(melody.currentDatumIndex).toBe(0);
   });
 
   it('should play the sequence forwards.', async () => {
@@ -37,7 +39,7 @@ describe('Melody', () => {
     expect(melody.isPlaying).toBeTrue();
     expect(melody.isEnded).toBeFalse();
     await new Promise(resolve => window.setTimeout(resolve, delay));
-    expect(melody.currentSeconds).toBeGreaterThan(0);
+    expect(melody.currentDatumIndex).toBeGreaterThan(0);
   });
 
   it('should play the sequence backwards.', async () => {
@@ -45,7 +47,7 @@ describe('Melody', () => {
     expect(melody.isPlaying).toBeTrue();
     expect(melody.isEnded).toBeFalse();
     await new Promise(resolve => window.setTimeout(resolve, delay));
-    expect(melody.currentSeconds).toBeLessThan(melody.duration);
+    expect(melody.currentDatumIndex).toBeLessThan(values.length - 1);
   });
 
   it('should pause the sequence.', async () => {
@@ -55,10 +57,10 @@ describe('Melody', () => {
     expect(melody.isPlaying).toBeFalse();
   });
 
-  it('should seek to the closest note to the given second.', () => {
+  it('should seek to the given index.', () => {
     for (let index = 0; index < values.length; index++) {
-      melody.seekTo(index * noteDuration);
-      expect(melody.getCurrentDatumIndex()).toBe(index);
+      melody.seekTo(index);
+      expect(melody.currentDatumIndex).toBe(index);
     }
   });
 });

--- a/src/models/melody/melody.model.ts
+++ b/src/models/melody/melody.model.ts
@@ -1,38 +1,38 @@
 import * as Tone from 'tone';
 
-export type OnSeek = (index: number, playing: boolean) => void;
+export type OnSeek = (index: number) => void;
 
 export class Melody {
+  currentDatumIndex = 0;
   private synth = new Tone.Synth().toDestination();
-  private forwardSequence: Tone.Sequence;
-  private backwardSequence: Tone.Sequence;
-  private currentDatumIndex = 0;
   private inclusive = true; // if true, playing the melody starting inclusively from currentDatumIndex
   private reversed = false; // if true, playing the melody backward
+  private readonly frequencies: number[];
+  private timeoutId: number | null = null;
 
   constructor(
     private values: number[],
     private frequencyRange: [number, number],
-    private noteDuration: number, // duration (in seconds) of a note
+    private noteDuration: number, // duration (in ms) of a note
     private onSeek?: OnSeek,
   ) {
-    const reversedValues = [...values].reverse();
-    this.forwardSequence = this.createSequence(values);
-    this.backwardSequence = this.createSequence(reversedValues);
+    const minValue = Math.min(...values);
+    const maxValue = Math.max(...values);
+    const [minFrequency, maxFrequency] = this.frequencyRange;
+    const minKeyNumber = Melody.getKeyNumber(minFrequency);
+    const maxKeyNumber = Melody.getKeyNumber(maxFrequency);
+    this.frequencies = values.map(value => {
+      const keyNumber = (value - minValue) / (maxValue - minValue) * (maxKeyNumber - minKeyNumber) + minKeyNumber;
+      return Melody.getFrequency(keyNumber);
+    });
   }
 
   get duration() {
     return this.noteDuration * this.values.length;
   }
 
-  get currentSeconds() {
-    return this.reversed
-      ? this.duration - Tone.Transport.seconds
-      : Tone.Transport.seconds;
-  }
-
   get isPlaying() {
-    return Tone.Transport.state === 'started';
+    return this.timeoutId !== null;
   }
 
   get isEnded() {
@@ -42,9 +42,9 @@ export class Melody {
     );
   }
 
-  get nextIndex() {
+  get nextDatumIndex() {
     if (this.isEnded) {
-      return (this.values.length - 1) - this.currentDatumIndex; // bring playhead to the opposite end
+      return this.reverseDatumIndex(this.currentDatumIndex); // bring playhead to the opposite end
     }
     const offset = this.inclusive ? 0 : (this.reversed ? -1 : +1);
     return this.currentDatumIndex + offset;
@@ -64,73 +64,41 @@ export class Melody {
     }
     if (!this.isPlaying) {
       this.reversed = reversed;
-      this.currentDatumIndex = this.nextIndex;
-      let nextSeconds = this.getSeconds(this.currentDatumIndex);
-      if (this.reversed) {
-        this.backwardSequence.start(0);
-        this.forwardSequence.stop(0);
-        nextSeconds += this.noteDuration / 2;
-        Tone.Transport.start(undefined, this.duration - nextSeconds);
-      } else {
-        this.backwardSequence.stop(0);
-        this.forwardSequence.start(0);
-        nextSeconds -= this.noteDuration / 2;
-        Tone.Transport.start(undefined, nextSeconds);
-      }
+      this.playNextNote();
     }
   }
 
   pause() {
-    if (this.isPlaying) {
-      Tone.Transport.pause();
-      this.backwardSequence.stop(0);
-      this.forwardSequence.stop(0);
-      this.seekTo(this.currentSeconds);
+    if (this.timeoutId !== null) {
+      window.clearInterval(this.timeoutId);
+      this.timeoutId = null;
     }
   }
 
-  getCurrentDatumIndex() {
-    return this.currentDatumIndex;
-  }
-
-  seekTo(seconds: number, inclusive = false) {
-    this.currentDatumIndex = this.getDatumIndex(seconds);
+  seekTo(datumIndex: number, inclusive = false) {
+    this.currentDatumIndex = datumIndex;
     this.inclusive = this.isEnded || inclusive;
-    this.onSeek?.(this.currentDatumIndex, this.isPlaying);
+    this.onSeek?.(this.currentDatumIndex);
   }
 
   dispose() {
-    this.forwardSequence.dispose();
-    this.backwardSequence.dispose();
+    this.pause();
     this.synth.dispose();
   }
 
-  private createSequence(values: number[]) {
-    const minValue = Math.min(...values);
-    const maxValue = Math.max(...values);
-    const [minFrequency, maxFrequency] = this.frequencyRange;
-    const minKeyNumber = Melody.getKeyNumber(minFrequency);
-    const maxKeyNumber = Melody.getKeyNumber(maxFrequency);
-    const sequence = new Tone.Sequence(
-      (time, value) => {
-        this.seekTo(this.currentSeconds);
-        const keyNumber = (value - minValue) / (maxValue - minValue) * (maxKeyNumber - minKeyNumber) + minKeyNumber;
-        const frequency = Melody.getFrequency(keyNumber);
-        this.synth.triggerAttackRelease(frequency, this.noteDuration, time);
-      },
-      values,
-      this.noteDuration,
-    );
-    sequence.loop = 1;
-    return sequence;
+  private playNextNote() {
+    this.seekTo(this.nextDatumIndex);
+    const frequency = this.frequencies[this.currentDatumIndex];
+    this.synth.triggerAttackRelease(frequency, this.noteDuration / 1000);
+    if (!this.isEnded) {
+      this.timeoutId = window.setTimeout(() => {
+        this.timeoutId = null;
+        this.playNextNote();
+      }, this.noteDuration);
+    }
   }
 
-  private getSeconds(index: number) {
-    return (index + .5) * this.noteDuration;
-  }
-
-  private getDatumIndex(seconds: number) {
-    const index = Math.round(seconds / this.noteDuration - .5);
-    return Math.min(Math.max(index, 0), this.values.length - 1);
+  private reverseDatumIndex(index: number) {
+    return (this.values.length - 1) - index;
   }
 }

--- a/src/services/preference/preference.service.ts
+++ b/src/services/preference/preference.service.ts
@@ -10,7 +10,7 @@ export class PreferenceService {
     enabled: new BehaviorSubject(true),
     lowestPitch: new BehaviorSubject(256),
     highestPitch: new BehaviorSubject(1024),
-    noteDuration: new BehaviorSubject(.167),
+    noteDuration: new BehaviorSubject(167),
     readBefore: new BehaviorSubject(false),
     readAfter: new BehaviorSubject(true),
   };


### PR DESCRIPTION
(Branched off of #22.)
Use `window.setTimeout` instead of `Tone.Transport` to play melody. Even though it is not accurate to within milliseconds, it guarantees to never skip a note and synchronize the active indicator with playhead perfectly.