### PR TITLE
Add rolling measure and period-over-period measure

### DIFF
--- a/src/components/line-chart/line-chart.component.ts
+++ b/src/components/line-chart/line-chart.component.ts
@@ -73,10 +73,10 @@ export class LineChartComponent implements RenderOptions, OnChanges, OnInit, OnD
         if (!rows.length) {
           return [];
         }
-        const firstMeasureName = rows[0].values.keys().next().value;
+        const [firstMeasureName] = Object.keys(rows[0].values);
         return rows.map(row => ({
-          date: row.categories.get('date') as Date,
-          value: row.values.get(firstMeasureName)!,
+          date: row.categories.date,
+          value: row.values[firstMeasureName],
         }));
       }))
       .subscribe(this.data$);

--- a/src/models/data-cube/data-cube.model.ts
+++ b/src/models/data-cube/data-cube.model.ts
@@ -160,13 +160,15 @@ export class DataCube {
     const traverseNode = (node: TrieNode) => {
       if (node.values) {
         result.push({
-          categories: new Map(
-            labelList.map((label, index) => [categoryNames[index], index === dateIndex ? new Date(+label) : label]),
-          ),
-          values: new Map(
-            node.values.map((value, index) => [measureNames[index], value]),
-          ),
-        });
+          categories: labelList.reduce((dictionary, label, index) => ({
+            ...dictionary,
+            [categoryNames[index]]: index === dateIndex ? new Date(+label) : label,
+          }), {}),
+          values: node.values.reduce((dictionary, value, index) => ({
+            ...dictionary,
+            [measureNames[index]]: value,
+          }), {}),
+        } as ResultRow);
       } else {
         for (const [label, child] of Object.entries(node.children)) {
           labelList.push(label);
@@ -194,8 +196,8 @@ export class DataCube {
     function getComparator(sortConcept: string) {
       if (categoryNames.includes(sortConcept)) {
         return (a: ResultRow, b: ResultRow) => {
-          const aCategory = a.categories.get(sortConcept)!;
-          const bCategory = b.categories.get(sortConcept)!;
+          const aCategory = a.categories[sortConcept];
+          const bCategory = b.categories[sortConcept];
           if (aCategory < bCategory) {
             return -1;
           }
@@ -207,7 +209,7 @@ export class DataCube {
       }
       if (measureNames.includes(sortConcept)) {
         return (a: ResultRow, b: ResultRow) =>
-          a.values.get(sortConcept)! - b.values.get(sortConcept)!;
+          a.values[sortConcept] - b.values[sortConcept];
       }
       return () => 0;
     }

--- a/src/models/data-cube/filters.ts
+++ b/src/models/data-cube/filters.ts
@@ -1,12 +1,27 @@
-import { Category, Filter, Row } from './types';
+import { Category, Filter, RangeOptions, Row } from './types';
 
-export function betweenDates(startDate: Date, endDate: Date): Filter {
+export function betweenDates(startDate: Date, endDate: Date, rangeOptions?: RangeOptions): Filter {
+  const dateRange: [Date, Date] = [startDate, endDate];
+  return inOneOfDateRanges([dateRange], rangeOptions);
+}
+
+export function inOneOfDateRanges(dateRanges: [Date, Date][], rangeOptions: RangeOptions = {}): Filter {
+  const {
+    excludeStart = false,
+    excludeEnd = false,
+  } = rangeOptions;
+  const startOffset = excludeStart ? 1 : 0;
+  const endOffset = excludeEnd ? -1 : 0;
   return (categories: Category[]) => {
     const dateIndex = categories.findIndex(
       category => category.name === 'date',
     );
     return (row: Row) =>
-      startDate.getTime() <= row.header[dateIndex] &&
-      row.header[dateIndex] <= endDate.getTime();
+      dateRanges.some(([startDate, endDate]) => {
+        const time = row.header[dateIndex];
+        const start = startDate.getTime() + startOffset;
+        const end = endDate.getTime() + endOffset;
+        return start <= time && time <= end;
+      });
   };
 }

--- a/src/models/data-cube/generation.ts
+++ b/src/models/data-cube/generation.ts
@@ -94,7 +94,7 @@ const defaultSettings: ModelSettings = {
   avgSessionsPerUser: 5,
   sessionsPerUserStdDev: 3,
   timeSeries: true,
-  startDate: new Date(Date.now() - 60 * DAY),
+  startDate: new Date(Date.now() - 90 * DAY),
   endDate: new Date(),
   dailyStdDev: 0.1,
 };

--- a/src/models/data-cube/types.ts
+++ b/src/models/data-cube/types.ts
@@ -97,6 +97,11 @@ export type Filter = (
   measures: Measure[],
 ) => (row: Row) => boolean;
 
+export interface RangeOptions {
+  excludeStart?: boolean;
+  excludeEnd?: boolean;
+}
+
 /**
  * The internal storage of the cube. Although the cube is conceptually an
  * n-dimensional cube of data, in actuality it is a list of rows, to make for
@@ -115,8 +120,8 @@ export interface Row {
  * dimension.
  */
 export interface ResultRow {
-  categories: Map<string, string | number | Date>;
-  values: Map<string, number>;
+  categories: Record<string, string | number | Date> & { date: Date };
+  values: Record<string, number>;
 }
 
 export interface QueryOptions {

--- a/src/services/data/data.service.ts
+++ b/src/services/data/data.service.ts
@@ -13,13 +13,17 @@ import { OnDestroy } from '@angular/core';
 import { map, takeUntil, throttleTime } from 'rxjs/operators';
 import { asyncScheduler, combineLatest, Observable, ReplaySubject, Subject } from 'rxjs';
 import { PreferenceService } from '../preference/preference.service';
-import { CompoundMeasure, CompoundMeasureType, PeriodOverPeriodMeasure, RollingMeasure, TimeSeriesQueryOptions } from './types';
+import { TimeSeriesQueryOptions } from './types';
 import { QueryOptions, ResultRow } from '../../models/data-cube/types';
 import {
+  CompoundMeasure,
+  CompoundMeasureType,
   destructureCompoundMeasure,
   isCompoundMeasure,
   namePeriodOverPeriodMeasure,
   nameRollingMeasure,
+  PeriodOverPeriodMeasure,
+  RollingMeasure,
 } from '../../utils/compoundMeasures';
 
 export class DataService implements OnDestroy {

--- a/src/services/data/data.service.ts
+++ b/src/services/data/data.service.ts
@@ -7,14 +7,14 @@ import {
   sourceCategory,
 } from '../../models/data-cube/presets';
 import { DataCube } from '../../models/data-cube/data-cube.model';
-import { betweenDates } from '../../models/data-cube/filters';
+import { betweenDates, inOneOfDateRanges } from '../../models/data-cube/filters';
 import { generateCube } from 'src/models/data-cube/generation';
 import { OnDestroy } from '@angular/core';
 import { map, takeUntil, throttleTime } from 'rxjs/operators';
 import { asyncScheduler, combineLatest, Observable, ReplaySubject, Subject } from 'rxjs';
 import { PreferenceService } from '../preference/preference.service';
-import { TimeSeriesQueryOptions } from './types';
-import { QueryOptions } from '../../models/data-cube/types';
+import { TimeSeriesQueryOptions, TimeSeriesWithComparisonQueryOptions } from './types';
+import { QueryOptions, ResultRow } from '../../models/data-cube/types';
 
 export class DataService implements OnDestroy {
   private dataCube$ = new ReplaySubject<DataCube>(1);
@@ -67,7 +67,7 @@ export class DataService implements OnDestroy {
           ...restOptions
         } = queryOptions;
         const categoryName = 'date';
-        const dateFilter = betweenDates(startDate, endDate);
+        const dateFilter = betweenDates(startDate, endDate, { excludeStart: true });
         return {
           ...restOptions,
           categoryNames: [categoryName, ...categoryNames],
@@ -76,5 +76,93 @@ export class DataService implements OnDestroy {
         };
       }));
     return this.observeData(queryOptions$);
+  }
+
+  observeTimeSeriesWithComparison(queryOptions$: Observable<TimeSeriesWithComparisonQueryOptions>) {
+    return combineLatest([this.dataCube$, queryOptions$])
+      .pipe(map(([dataCube, queryOptions]) => {
+        const {
+          startDate, endDate,
+          rollingUnits = [], periodOverPeriodOffsets = [],
+          categoryNames = [], measureNames = [], filters = [], sortBy = [],
+          ...restOptions
+        } = queryOptions;
+
+        const categoryName = 'date';
+        const duration = endDate.getTime() - startDate.getTime();
+        const maxRollingUnit = Math.max(0, ...rollingUnits);
+        const dateRanges: [Date, Date][] = [0, ...periodOverPeriodOffsets].map(periodOffset => {
+          const periodStart = startDate.getTime() + periodOffset;
+          const rangeStartDate = new Date(periodStart - maxRollingUnit);
+          const rangeEndDate = new Date(periodStart + duration);
+          return [rangeStartDate, rangeEndDate];
+        });
+        const dateFilter = inOneOfDateRanges(dateRanges, { excludeStart: true });
+
+        const rawData = dataCube.getDataFor({
+          ...restOptions,
+          categoryNames: [categoryName, ...categoryNames],
+          measureNames,
+          filters: [dateFilter, ...filters],
+          sortBy: [categoryName, ...sortBy],
+        });
+        const data = rawData.filter(datum => {
+          const { date } = datum.categories;
+          return startDate < date && date <= endDate;
+        });
+
+        for (const measureName of measureNames) {
+          for (const rollingUnit of rollingUnits) {
+            this.attachRollingMeasure(rawData, data, measureName, rollingUnit);
+          }
+          for (const periodOffset of periodOverPeriodOffsets) {
+            this.attachPeriodOverPeriodMeasure(rawData, data, measureName, periodOffset);
+          }
+        }
+
+        return data;
+      }));
+  }
+
+  private attachRollingMeasure(rawData: ResultRow[], data: ResultRow[], measureName: string, rollingUnit: number) {
+    const newMeasureName = `${measureName}-rolling-${rollingUnit}`;
+    const [headDatum, ...tailData] = data;
+
+    // pre-calculate the sum of the window for the very first datum
+    const rollingStart = headDatum.categories.date.getTime() - rollingUnit;
+    let startIndex = rawData.findIndex(datum => rollingStart < datum.categories.date.getTime());
+    if (startIndex < 0) {
+      return;
+    }
+    let endIndex = rawData.indexOf(headDatum);
+    let sum = rawData
+      .slice(startIndex, endIndex + 1)
+      .reduce((acc, datum) => acc + datum.values[measureName], 0);
+    headDatum.values[newMeasureName] = sum;
+
+    // slide the window for the rest of the data
+    for (const datum of tailData) {
+      sum += rawData[++endIndex].values[measureName];
+      sum -= rawData[startIndex++].values[measureName];
+      datum.values[newMeasureName] = sum;
+    }
+  }
+
+  private attachPeriodOverPeriodMeasure(rawData: ResultRow[], data: ResultRow[], measureName: string, periodOffset: number) {
+    const newMeasureName = `${measureName}-pop-${periodOffset}`;
+    const [headDatum, ...tailData] = data;
+
+    // find the corresponding datum to the very first datum
+    const periodStart = headDatum.categories.date.getTime() + periodOffset;
+    let index = rawData.findIndex(datum => periodStart === datum.categories.date.getTime());
+    if (index < 0) {
+      return;
+    }
+    headDatum.values[newMeasureName] = rawData[index].values[measureName];
+
+    // slide the corresponding datum for the rest of the data
+    for (const datum of tailData) {
+      datum.values[newMeasureName] = rawData[++index].values[measureName];
+    }
   }
 }

--- a/src/services/data/types.ts
+++ b/src/services/data/types.ts
@@ -5,7 +5,24 @@ export interface TimeSeriesQueryOptions extends QueryOptions {
   endDate: Date;
 }
 
-export interface TimeSeriesWithComparisonQueryOptions extends TimeSeriesQueryOptions {
-  rollingUnits?: number[];
-  periodOverPeriodOffsets?: number[];
+export const COMPOUND_MEASURE_DELIMITER = '$$';
+
+export enum CompoundMeasureType {
+  ROLLING,
+  PERIOD_OVER_PERIOD,
+}
+
+export interface CompoundMeasure {
+  originalMeasureName: string;
+  type: CompoundMeasureType;
+}
+
+export interface RollingMeasure extends CompoundMeasure {
+  type: CompoundMeasureType.ROLLING;
+  windowSize: number;
+}
+
+export interface PeriodOverPeriodMeasure extends CompoundMeasure {
+  type: CompoundMeasureType.PERIOD_OVER_PERIOD;
+  periodOffset: number;
 }

--- a/src/services/data/types.ts
+++ b/src/services/data/types.ts
@@ -4,3 +4,8 @@ export interface TimeSeriesQueryOptions extends QueryOptions {
   startDate: Date;
   endDate: Date;
 }
+
+export interface TimeSeriesWithComparisonQueryOptions extends TimeSeriesQueryOptions {
+  rollingUnits?: number[];
+  periodOverPeriodOffsets?: number[];
+}

--- a/src/services/data/types.ts
+++ b/src/services/data/types.ts
@@ -4,25 +4,3 @@ export interface TimeSeriesQueryOptions extends QueryOptions {
   startDate: Date;
   endDate: Date;
 }
-
-export const COMPOUND_MEASURE_DELIMITER = '$$';
-
-export enum CompoundMeasureType {
-  ROLLING,
-  PERIOD_OVER_PERIOD,
-}
-
-export interface CompoundMeasure {
-  originalMeasureName: string;
-  type: CompoundMeasureType;
-}
-
-export interface RollingMeasure extends CompoundMeasure {
-  type: CompoundMeasureType.ROLLING;
-  windowSize: number;
-}
-
-export interface PeriodOverPeriodMeasure extends CompoundMeasure {
-  type: CompoundMeasureType.PERIOD_OVER_PERIOD;
-  periodOffset: number;
-}

--- a/src/utils/compoundMeasures.ts
+++ b/src/utils/compoundMeasures.ts
@@ -1,11 +1,24 @@
-import {
-  COMPOUND_MEASURE_DELIMITER,
-  CompoundMeasure,
-  CompoundMeasureType,
-  PeriodOverPeriodMeasure,
-  RollingMeasure,
-} from '../services/data/types';
+export enum CompoundMeasureType {
+  ROLLING,
+  PERIOD_OVER_PERIOD,
+}
 
+export interface CompoundMeasure {
+  originalMeasureName: string;
+  type: CompoundMeasureType;
+}
+
+export interface RollingMeasure extends CompoundMeasure {
+  type: CompoundMeasureType.ROLLING;
+  windowSize: number;
+}
+
+export interface PeriodOverPeriodMeasure extends CompoundMeasure {
+  type: CompoundMeasureType.PERIOD_OVER_PERIOD;
+  periodOffset: number;
+}
+
+export const COMPOUND_MEASURE_DELIMITER = '$$';
 
 export function isCompoundMeasure(measureName: string) {
   return measureName.includes(COMPOUND_MEASURE_DELIMITER);

--- a/src/utils/compoundMeasures.ts
+++ b/src/utils/compoundMeasures.ts
@@ -1,0 +1,35 @@
+import {
+  COMPOUND_MEASURE_DELIMITER,
+  CompoundMeasure,
+  CompoundMeasureType,
+  PeriodOverPeriodMeasure,
+  RollingMeasure,
+} from '../services/data/types';
+
+
+export function isCompoundMeasure(measureName: string) {
+  return measureName.includes(COMPOUND_MEASURE_DELIMITER);
+}
+
+function nameCompoundMeasure(originalMeasureName: string, type: CompoundMeasureType, ...params: (string | number)[]) {
+  return [originalMeasureName, type, ...params].join(COMPOUND_MEASURE_DELIMITER);
+}
+
+export function nameRollingMeasure(originalMeasureName: string, windowSize: number) {
+  return nameCompoundMeasure(originalMeasureName, CompoundMeasureType.ROLLING, windowSize);
+}
+
+export function namePeriodOverPeriodMeasure(originalMeasureName: string, periodOffset: number) {
+  return nameCompoundMeasure(originalMeasureName, CompoundMeasureType.PERIOD_OVER_PERIOD, periodOffset);
+}
+
+export function destructureCompoundMeasure(measureName: string): CompoundMeasure {
+  const [originalMeasureName, type, ...params] = measureName.split(COMPOUND_MEASURE_DELIMITER);
+  switch (+type) {
+    case CompoundMeasureType.ROLLING:
+      return { originalMeasureName, type: +type, windowSize: +params[0] } as RollingMeasure;
+    case CompoundMeasureType.PERIOD_OVER_PERIOD:
+      return { originalMeasureName, type: +type, periodOffset: +params[0] } as PeriodOverPeriodMeasure;
+  }
+  throw new Error('Unknown compound measure type.');
+}


### PR DESCRIPTION
Add methods in `DataService` to populate rolling measure and period-over-period measure after querying to `DataCube`.

Rolling measure would be to represent:
![Screen Shot 2020-06-26 at 6 02 58 PM](https://user-images.githubusercontent.com/1618732/85904711-6e069c00-b7d7-11ea-8649-3d1002bffa0b.png)

Period over period measure:
![Screen Shot 2020-06-26 at 6 04 54 PM](https://user-images.githubusercontent.com/1618732/85904759-8ecef180-b7d7-11ea-9adc-9fbd0f5443cb.png)
