### PR TITLE
Update xy-chart / line-chart tests

### DIFF
--- a/src/components/line-chart-audification/line-chart-audification.component.spec.ts
+++ b/src/components/line-chart-audification/line-chart-audification.component.spec.ts
@@ -63,10 +63,10 @@ describe('LineChartAudificationComponent', () => {
     component.readAfter = true;
 
     host.ngOnInit();
-    component.ngOnInit();
     host.ngOnChanges({
       meta: new SimpleChange(null, host.meta, true),
     });
+    component.ngOnInit();
   });
 
   it('should instantiate.', () => {

--- a/src/components/line-chart/line-chart.component.spec.ts
+++ b/src/components/line-chart/line-chart.component.spec.ts
@@ -30,7 +30,7 @@ describe('LineChartComponent', () => {
 
   it('should have truthy i18n values.', () => {
     component.activePoint = mockPoint;
-    expect(component.ACTIVE_DATUM).toBeTruthy();
+    expect(component.VISUALIZATION).toBeTruthy();
   });
 
   it('should synchronize activePoint with activePoint$.', () => {

--- a/src/d3/base.d3.spec.ts
+++ b/src/d3/base.d3.spec.ts
@@ -17,12 +17,8 @@ describe('BaseD3', () => {
     containerElement.appendChild(svgElement);
     renderOptions = {
       elementRef: new ElementRef<HTMLElement>(containerElement),
-      height: 256,
       width: 256,
-      marginTop: 8,
-      marginRight: 8,
-      marginBottom: 8,
-      marginLeft: 8,
+      height: 256,
     };
     baseD3 = new TestBaseD3(renderOptions);
   });

--- a/src/d3/line-chart.d3.spec.ts
+++ b/src/d3/line-chart.d3.spec.ts
@@ -64,11 +64,11 @@ describe('LineChartD3', () => {
 
   it('should update the active point upon changes.', async () => {
     lineChartD3.render();
-    const circleElement = svgElement.querySelector('.line_chart-active_point')!;
-    const transformAttribute = circleElement.getAttribute('transform');
+    const activePointElement = svgElement.querySelector('.line_chart-active_point')!;
+    const transformAttribute = activePointElement.getAttribute('transform');
     renderOptions.activePoint$.next(mockPoint);
     await new Promise(resolve => setTimeout(resolve, transitionDelay));
-    const newTransformAttribute = circleElement.getAttribute('transform');
+    const newTransformAttribute = activePointElement.getAttribute('transform');
     expect(newTransformAttribute).not.toBe(transformAttribute);
   });
 

--- a/src/d3/line-chart.d3.spec.ts
+++ b/src/d3/line-chart.d3.spec.ts
@@ -1,30 +1,34 @@
 import { ElementRef } from '@angular/core';
 import { Subject } from 'rxjs';
 import { LineChartD3 } from './line-chart.d3';
-import { mockDatum, mockPoint } from '../utils/mocks.spec';
+import { mockData, mockPoint } from '../utils/mocks.spec';
 import { TimeSeriesPoint } from '../datasets/queries/time-series.query';
 import { LineChartDatum } from '../components/line-chart/line-chart.component';
 import { RenderOptions } from './xy-chart.d3';
 
+interface SubjectRenderOptions extends RenderOptions<LineChartDatum> {
+  data$: Subject<LineChartDatum[]>;
+  activePoint$: Subject<TimeSeriesPoint | null>;
+}
+
 describe('LineChartD3', () => {
-  const svgElement = document.createElement('svg');
-  const containerElement = document.createElement('div');
-  containerElement.appendChild(svgElement);
-  const renderOptions = {
-    elementRef: new ElementRef<HTMLElement>(containerElement),
-    height: 256,
-    width: 256,
-    marginTop: 8,
-    marginRight: 8,
-    marginBottom: 8,
-    marginLeft: 8,
-    datum$: new Subject<LineChartDatum>(),
-    activePoint$: new Subject<TimeSeriesPoint | null>(),
-  };
+  let containerElement: HTMLElement;
+  let svgElement: HTMLElement;
+  let renderOptions: SubjectRenderOptions;
   let lineChartD3: LineChartD3;
   const transitionDelay = 350;
 
   beforeEach(() => {
+    svgElement = document.createElement('svg');
+    containerElement = document.createElement('div');
+    containerElement.appendChild(svgElement);
+    renderOptions = {
+      elementRef: new ElementRef<HTMLElement>(containerElement),
+      width: 256,
+      height: 256,
+      data$: new Subject<LineChartDatum[]>(),
+      activePoint$: new Subject<TimeSeriesPoint | null>(),
+    };
     lineChartD3 = new LineChartD3(renderOptions);
   });
 
@@ -36,31 +40,31 @@ describe('LineChartD3', () => {
     expect(lineChartD3).toBeInstanceOf(LineChartD3);
   });
 
-  it('should render a path element for the data.', () => {
+  it('should update the data upon changes.', async () => {
     lineChartD3.render();
-    const pathElement = svgElement.querySelector('path');
-    expect(pathElement).toBeTruthy();
-  });
-
-  it('should update the path element upon the data change.', async () => {
-    lineChartD3.render();
-    const pathElement = svgElement.querySelector('path')!;
-    const dAttribute = pathElement.getAttribute('d');
-    renderOptions.datum$.next(mockDatum);
+    renderOptions.data$.next([mockData[0]]);
     await new Promise(resolve => setTimeout(resolve, transitionDelay));
-    const newDAttribute = pathElement.getAttribute('d');
-    expect(newDAttribute).not.toBe(dAttribute);
+    const pathElement = svgElement.querySelector('.xy_chart-data path');
+    expect(pathElement).not.toBe(null);
+
+    if (pathElement !== null) {
+      const dAttribute = pathElement.getAttribute('d');
+      renderOptions.data$.next([mockData[1]]);
+      await new Promise(resolve => setTimeout(resolve, transitionDelay));
+      const newDAttribute = pathElement.getAttribute('d');
+      expect(newDAttribute).not.toBe(dAttribute);
+    }
   });
 
-  it('should render a circle element for the active datum.', async () => {
+  it('should render the active point.', async () => {
     lineChartD3.render();
-    const circleElement = svgElement.querySelector('circle');
-    expect(circleElement).toBeTruthy();
+    const activePointElement = svgElement.querySelector('.line_chart-active_point');
+    expect(activePointElement).toBeTruthy();
   });
 
-  it('should update the circle element upon the active datum changes.', async () => {
+  it('should update the active point upon changes.', async () => {
     lineChartD3.render();
-    const circleElement = svgElement.querySelector('circle')!;
+    const circleElement = svgElement.querySelector('.line_chart-active_point')!;
     const transformAttribute = circleElement.getAttribute('transform');
     renderOptions.activePoint$.next(mockPoint);
     await new Promise(resolve => setTimeout(resolve, transitionDelay));
@@ -68,9 +72,9 @@ describe('LineChartD3', () => {
     expect(newTransformAttribute).not.toBe(transformAttribute);
   });
 
-  it('should only show the circle element when the active datum is non-null.', async () => {
+  it('should only show the active point when non-null.', async () => {
     lineChartD3.render();
-    const circleElement = svgElement.querySelector('circle')!;
+    const circleElement = svgElement.querySelector('.line_chart-active_point')!;
 
     renderOptions.activePoint$.next(mockPoint);
     await new Promise(resolve => setTimeout(resolve, transitionDelay));

--- a/src/d3/line-chart.d3.ts
+++ b/src/d3/line-chart.d3.ts
@@ -27,6 +27,8 @@ export class LineChartD3 extends XYChartD3<LegendItemStyle> {
   protected activePointCircle: d3.Selection<SVGCircleElement, unknown, null, undefined>;
 
   protected renderData() {
+    super.renderData();
+
     this.linePaths = [];
   }
 
@@ -43,7 +45,7 @@ export class LineChartD3 extends XYChartD3<LegendItemStyle> {
       for (let i = 0; i < itemCount - oldItemCount; i++) {
         this.linePaths.push({
           line: d3.line<TimeSeriesPoint>(),
-          path: this.svg
+          path: this.dataG
             .append('path')
             .attr('fill', 'none')
             .attr('stroke-linejoin', 'round')
@@ -64,12 +66,12 @@ export class LineChartD3 extends XYChartD3<LegendItemStyle> {
         .transition(this.transition)
         .attr('d', line);
     });
-
   }
 
   protected renderActivePoint() {
     this.activePointCircle = this.svg
       .append('circle')
+      .attr('class', 'line_chart-active_point')
       .attr('r', 4)
       .attr('fill', LineChartD3.colorPrimary);
   }

--- a/src/d3/xy-chart.d3.spec.ts
+++ b/src/d3/xy-chart.d3.spec.ts
@@ -22,6 +22,7 @@ describe('XYChartD3', () => {
     activePointFlag = 0;
 
     protected renderData() {
+      super.renderData();
       this.dataFlag = 1;
     }
 

--- a/src/d3/xy-chart.d3.spec.ts
+++ b/src/d3/xy-chart.d3.spec.ts
@@ -1,22 +1,31 @@
-import { ElementRef } from '@angular/core';
-import { XYChartD3 } from './xy-chart.d3';
+import { RenderOptions, XYChartD3 } from './xy-chart.d3';
 import { Subject } from 'rxjs';
-import { TimeSeriesPoint } from '../datasets/queries/time-series.query';
+import { TimeSeriesDatum, TimeSeriesPoint } from '../datasets/queries/time-series.query';
+import { mockData } from '../utils/mocks.spec';
+import { ElementRef } from '@angular/core';
 import { LineChartDatum } from '../components/line-chart/line-chart.component';
-import { mockDatum } from '../utils/mocks.spec';
+
+type TestLegendItemStyle = {};
+
+type TestDatum = TimeSeriesDatum<TestLegendItemStyle>;
+
+interface SubjectRenderOptions extends RenderOptions<TestDatum> {
+  data$: Subject<TestDatum[]>;
+  activePoint$: Subject<TimeSeriesPoint | null>;
+}
 
 describe('XYChartD3', () => {
   // since XYChartD3 is an abstract class, make a concrete child class
-  class TestXYChartD3 extends XYChartD3 {
+  class TestXYChartD3 extends XYChartD3<TestLegendItemStyle> {
     // the flags below will be used to check if the methods have been called at the right time
-    activePointFlag = 0;
     dataFlag = 0;
+    activePointFlag = 0;
 
     protected renderData() {
       this.dataFlag = 1;
     }
 
-    protected updateData(data: TimeSeriesPoint[]) {
+    protected updateData(data: TestDatum[]) {
       this.dataFlag = 2;
     }
 
@@ -27,25 +36,27 @@ describe('XYChartD3', () => {
     protected updateActivePoint(activePoint: TimeSeriesPoint | null) {
       this.activePointFlag = 2;
     }
+
+    protected appendLegendItemIcon(itemG: d3.Selection<SVGGElement, unknown, null, undefined>, datum: TestDatum) {
+    }
   }
 
-  const svgElement = document.createElement('svg');
-  const containerElement = document.createElement('div');
-  containerElement.appendChild(svgElement);
-  const renderOptions = {
-    elementRef: new ElementRef<HTMLElement>(containerElement),
-    height: 256,
-    width: 256,
-    marginTop: 8,
-    marginRight: 8,
-    marginBottom: 8,
-    marginLeft: 8,
-    datum$: new Subject<LineChartDatum>(),
-    activePoint$: new Subject<TimeSeriesPoint | null>(),
-  };
+  let containerElement: HTMLElement;
+  let svgElement: HTMLElement;
+  let renderOptions: SubjectRenderOptions;
   let xyChartD3: TestXYChartD3;
 
   beforeEach(() => {
+    svgElement = document.createElement('svg');
+    containerElement = document.createElement('div');
+    containerElement.appendChild(svgElement);
+    renderOptions = {
+      elementRef: new ElementRef<HTMLElement>(containerElement),
+      width: 256,
+      height: 256,
+      data$: new Subject<LineChartDatum[]>(),
+      activePoint$: new Subject<TimeSeriesPoint | null>(),
+    };
     xyChartD3 = new TestXYChartD3(renderOptions);
   });
 
@@ -61,7 +72,7 @@ describe('XYChartD3', () => {
     expect(xyChartD3.dataFlag).toBe(0);
     xyChartD3.render();
     expect(xyChartD3.dataFlag).toBe(1);
-    renderOptions.datum$.next(mockDatum);
+    renderOptions.data$.next(mockData);
     expect(xyChartD3.dataFlag).toBe(2);
   });
 
@@ -73,9 +84,11 @@ describe('XYChartD3', () => {
     expect(xyChartD3.activePointFlag).toBe(2);
   });
 
-  it('should render two g elements for the axis.', () => {
+  it('should render the x and y axis.', () => {
     xyChartD3.render();
-    const gElements = svgElement.querySelectorAll('g');
-    expect(gElements.length).toBe(2);
+    const xAxisElement = svgElement.querySelector('.xy_chart-x_axis');
+    const yAxisElement = svgElement.querySelector('.xy_chart-y_axis');
+    expect(xAxisElement).not.toBe(null);
+    expect(yAxisElement).not.toBe(null);
   });
 });

--- a/src/d3/xy-chart.d3.spec.ts
+++ b/src/d3/xy-chart.d3.spec.ts
@@ -91,4 +91,11 @@ describe('XYChartD3', () => {
     expect(xAxisElement).not.toBe(null);
     expect(yAxisElement).not.toBe(null);
   });
+
+  it('should render the legend.', () => {
+    xyChartD3.render();
+    renderOptions.data$.next(mockData);
+    const textElements = svgElement.querySelectorAll('.xy_chart-legend text');
+    expect(textElements.length).toBe(mockData.length);
+  });
 });

--- a/src/d3/xy-chart.d3.ts
+++ b/src/d3/xy-chart.d3.ts
@@ -27,6 +27,7 @@ export abstract class XYChartD3<LegendItemStyle,
   protected yAxis: d3.Axis<number>;
   protected xAxisG: d3.Selection<SVGGElement, unknown, null, undefined>;
   protected yAxisG: d3.Selection<SVGGElement, unknown, null, undefined>;
+  protected dataG: d3.Selection<SVGGElement, unknown, null, undefined>;
   protected legendG: d3.Selection<SVGGElement, unknown, null, undefined>;
 
   x(value: Date) {
@@ -71,6 +72,7 @@ export abstract class XYChartD3<LegendItemStyle,
 
     this.legendG = this.svg
       .append('g')
+      .attr('class', 'xy_chart-legend')
       .attr('transform', `translate(${left},${top})`);
   }
 
@@ -91,7 +93,8 @@ export abstract class XYChartD3<LegendItemStyle,
         .attr('font-size', fontSizeMedium)
         .attr('transform', `translate(${textOffsetX}, ${fontSizeMedium})`)
         .text(datum.label);
-      const textWidth = measureText.node()!.getBBox().width;
+      const fallbackTextWidth = datum.label.length * fontSizeMedium / 2;
+      const textWidth = measureText.node()?.getBBox?.().width ?? fallbackTextWidth;
       offsetX += textOffsetX + textWidth + fontSizeMedium;
     }
   }
@@ -121,10 +124,12 @@ export abstract class XYChartD3<LegendItemStyle,
 
     this.xAxisG = this.svg
       .append('g')
+      .attr('class', 'xy_chart-x_axis')
       .attr('transform', `translate(0,${bottom})`)
       .attr('font-size', fontSizeSmall);
     this.yAxisG = this.svg
       .append('g')
+      .attr('class', 'xy_chart-y_axis')
       .attr('transform', `translate(${left},0)`)
       .attr('font-size', fontSizeSmall);
   }
@@ -144,7 +149,11 @@ export abstract class XYChartD3<LegendItemStyle,
       .call(this.yAxis);
   }
 
-  protected abstract renderData();
+  protected renderData() {
+    this.dataG = this.svg
+      .append('g')
+      .attr('class', 'xy_chart-data');
+  }
 
   protected abstract updateData(data: Datum[]);
 

--- a/src/utils/mocks.spec.ts
+++ b/src/utils/mocks.spec.ts
@@ -2,6 +2,7 @@ import { AudificationPreference, Preference } from '../services/preference/types
 import { TimeSeriesPoint } from '../datasets/queries/time-series.query';
 import { activeUserMeasure } from '../models/data-cube/presets';
 import { LineChartDatum } from '../components/line-chart/line-chart.component';
+import { DAY } from './timeUnits';
 
 export const mockPreference: Preference = {
   enabled: false,
@@ -16,14 +17,24 @@ export const mockAudificationPreference: AudificationPreference = {
   readBefore: false,
 };
 
-export const mockPoint: TimeSeriesPoint = {
-  x: new Date(),
-  y: 0,
-};
+function createMockPoints(length = 30, max = 50): TimeSeriesPoint[] {
+  return new Array(length).fill(0).map((_, i) => ({
+    x: new Date(Date.now() - (length - i - 1) * DAY),
+    y: Math.random() * max,
+  }));
+}
 
-export const mockDatum: LineChartDatum = {
-  label: '',
-  points: [mockPoint],
-};
+export const mockPoints = createMockPoints();
+export const [mockPoint] = createMockPoints(1);
+
+function createMockData(length = 5): LineChartDatum[] {
+  return new Array(length).fill(0).map((_, i) => ({
+    label: `Datum ${i}`,
+    points: createMockPoints(),
+  }));
+}
+
+export const mockData = createMockData();
+export const [mockDatum] = createMockData(1);
 
 export const mockMeasureName = activeUserMeasure.name;


### PR DESCRIPTION
- Init elements within beforeEach.
- Randomly generate mock points / data.
- Add a class name to each of svg elements for easy access in tests.
- Fix broken tests.
- Add missing tests.