### PR TITLE
adds haptic triggers to data entities

### DIFF
--- a/src/components/vr-accessibility/vr-accessibility.component.html
+++ b/src/components/vr-accessibility/vr-accessibility.component.html
@@ -6,8 +6,8 @@
   <a-assets></a-assets>
   <a-entity>
     <a-camera></a-camera>
-    <a-entity sphere-collider super-hands oculus-touch-controls="hand: left;" haptics="events: triggerdown; dur: 1000; force: 0.5"></a-entity>
-    <a-entity sphere-collider super-hands oculus-touch-controls="hand: right;" haptics="events: triggerdown; dur: 1000; force: 0.5"></a-entity>
+    <a-entity sphere-collider super-hands oculus-touch-controls="hand: left;" haptics="force: 0"></a-entity>
+    <a-entity sphere-collider super-hands oculus-touch-controls="hand: right;" haptics="force: 0"></a-entity>
   </a-entity>
   <a-box hoverable grabbable stretchable draggable dropppable color="green" position="-1 0 -1"></a-box>
 </a-scene>

--- a/src/components/vr-accessibility/vr-accessibility.component.ts
+++ b/src/components/vr-accessibility/vr-accessibility.component.ts
@@ -32,7 +32,7 @@ export class VRAccessibilityComponent implements OnInit, OnChanges, OnDestroy, A
 
   ngAfterViewInit(){
     const scene = this.theScene.nativeElement;
-    this.vrHapticPlot.init(scene, [0, 1 / 5, 2 / 5, 3 / 5, 4 / 5, 5 / 5, 6 / 5]);
+    this.vrHapticPlot.init(scene, [0, 0, 0.5, 0.5, 1, 1]);
   }
 
 }

--- a/src/d3/hapticplot.d3.spec.ts
+++ b/src/d3/hapticplot.d3.spec.ts
@@ -65,7 +65,7 @@ describe('VR Haptic Plot', () => {
 
 // Helper Functions
 
-// returns array of actual position vectors
+// Returns an array of actual position vectors
 function getPosition(scene: HTMLElement, shape: string): Vector3[]{
   const attrArray: Vector3[] = [];
   Array.from(scene.querySelectorAll(shape)).forEach((child) => {
@@ -77,25 +77,26 @@ function getPosition(scene: HTMLElement, shape: string): Vector3[]{
   return attrArray;
 }
 
-// returns array of each generated objects color
+// Returns an array of each generated objects color
 function getColor(scene: HTMLElement, shape: string): (string | null)[]{
   return Array.from(scene.querySelectorAll(shape)).map((point: Element) => point.getAttribute('color'));
 }
 
-// returns array of each generated objects radius
+// Returns an array of each generated objects radius
 function getRadius(scene: HTMLElement, shape: string): (string | null)[]{
   return Array.from(scene.querySelectorAll(shape)).map((point: Element) => point.getAttribute('radius'));
 }
 
-// returns array of each generated objects hover property
+// Returns an array of each generated objects hover property
 function getHoverable(scene: HTMLElement, shape: string): (string | undefined)[]{
-  const attrArray: (string | undefined)[] = [];
-  Array.from(scene.querySelectorAll(shape)).forEach((child) => { attrArray.push((child as Entity).components.hoverable.attrName); });
-  return attrArray;
+  return Array.from(scene.querySelectorAll(shape)).map((point: Element) => (point as Entity).components.hoverable.attrName);
 }
 
-// returns array of each generated objects color, after a hover event has occured
+// Returns an array of each generated objects color, after a hover event has occured
 function getHoveredColor(scene: HTMLElement, shape: string): (string | null)[]{
-  Array.from(scene.querySelectorAll(shape)).forEach((child) => { child.dispatchEvent(new Event('hover-start')); });
+  const shapes = scene.querySelectorAll(shape);
+  for (const point of Array.from(shapes)){
+    point.dispatchEvent(new Event('hover-start'));
+  }
   return Array.from(scene.querySelectorAll(shape)).map((point: Element) => point.getAttribute('color'));
 }

--- a/src/d3/hapticplot.d3.spec.ts
+++ b/src/d3/hapticplot.d3.spec.ts
@@ -1,5 +1,6 @@
 import { Hapticplot } from './hapticplot.d3';
 import { Entity } from 'aframe';
+import { Vector3 } from 'three';
 
 
 describe('VR Haptic Plot', () => {
@@ -21,25 +22,14 @@ describe('VR Haptic Plot', () => {
 
   it('places points for each datum in a one datum array', () => {
     hapticplot.init(scene, [10]);
-    const expectedPosArray = [{ x: 0, y: 10, z: -1 }];
+    const expectedPosArray = [new Vector3(0, 10, -1)];
     const result = getPosition(scene, shape);
     expect(result).toEqual(expectedPosArray);
   });
 
-  it('places points for each datum in a two datum array', () => {
-    hapticplot.init(scene, [10, 10]);
-    const expectedPosArray = [{ x: 0, y: 10, z: -1 }, { x: 0.1, y: 10, z: -1 }];
-    const result = getPosition(scene, shape);
-    expect(result).toEqual(expectedPosArray);
-  });
-
-  it('places points for each datum in a eight datum array', () => {
-    hapticplot.init(scene, [10, 10, 20, 20, 30, 30, 40, 40]);
-    const expectedPosArray = [
-      { x: 0, y: 10, z: -1 }, { x: 0.10, y: 10, z: -1 },
-      { x: 0.2, y: 20, z: -1 }, { x: 0.3, y: 20, z: -1 },
-      { x: 0.4, y: 30, z: -1 }, { x: 0.5, y: 30, z: -1 },
-     { x: 0.6, y: 40, z: -1 }, { x: 0.7, y: 40, z: -1 }];
+  it('places points for each datum in a three datum array', () => {
+    hapticplot.init(scene, [0, 10, 20]);
+    const expectedPosArray = [new Vector3(0, 0, -1), new Vector3(0.1, 10, -1), new Vector3(0.2, 20, -1)];
     const result = getPosition(scene, shape);
     expect(result).toEqual(expectedPosArray);
   });
@@ -76,13 +66,15 @@ describe('VR Haptic Plot', () => {
 // Helper Functions
 
 // returns array of actual position vectors
-function getPosition(scene: HTMLElement, shape: string): Array<{x: number, y: number, z: number}>{
-  const childrenArray = scene.querySelectorAll(shape);
-  const positionArray: Array<{x: number, y: number, z: number}> = [];
-  for (const child of (childrenArray as any)){
-    positionArray.push((child as any).components.position.attrValue);
-  }
-  return positionArray;
+function getPosition(scene: HTMLElement, shape: string): Vector3[]{
+  const attrArray: Vector3[] = [];
+  Array.from(scene.querySelectorAll(shape)).forEach((child) => {
+    attrArray.push(new Vector3(
+      (child as Entity).object3D.position.x,
+      (child as Entity).object3D.position.y,
+      (child as Entity).object3D.position.z));
+  });
+  return attrArray;
 }
 
 // returns array of each generated objects color

--- a/src/d3/hapticplot.d3.spec.ts
+++ b/src/d3/hapticplot.d3.spec.ts
@@ -1,5 +1,6 @@
 import { Hapticplot } from './hapticplot.d3';
-import { resolve } from 'dns';
+import { $ } from 'protractor';
+
 
 describe('VR Haptic Plot', () => {
   const shape = 'a-sphere';
@@ -42,6 +43,20 @@ describe('VR Haptic Plot', () => {
     const result = getPosition(element, shape);
     expect(result).toEqual(expectedPosArray);
   });
+
+  it('places points for each element in a three element array, and checks their color property', () => {
+    hapticplot.init(element, [10, 20, 30]);
+    const expectedColorArray = ['green', 'green' , 'green'];
+    const result = getColor(element, shape);
+    expect(result).toEqual(expectedColorArray);
+  });
+
+  it('places points for each element in a three element array, and checks their size property', () => {
+    hapticplot.init(element, [10, 20, 30]);
+    const expectedSizeArray = ['0.05', '0.05', '0.05'];
+    const result = getRadius(element, shape);
+    expect(result).toEqual(expectedSizeArray);
+  });
 });
 
 // returns array of actual position vectors
@@ -52,4 +67,30 @@ function getPosition(element: HTMLElement, shape: string): Array<{x: number, y: 
     positionArray.push((child as any).components.position.attrValue);
   }
   return positionArray;
+}
+
+/*
+*
+Helper Functions
+*
+*/
+
+// returns array of each generated objects color
+function getColor(element: HTMLElement, shape: string): Array<string>{
+  const childrenArray = element.querySelectorAll(shape);
+  const colorArray: Array<string> = [];
+  for (const child of (childrenArray as any)){
+    colorArray.push((child as any).getAttribute('color'));
+  }
+  return colorArray;
+}
+
+// returns array of each generated objects radius
+function getRadius(element: HTMLElement, shape: string): Array<string>{
+  const childrenArray = element.querySelectorAll(shape);
+  const sizeArray: Array<string> = [];
+  for (const child of (childrenArray as any)){
+    sizeArray.push((child as any).getAttribute('radius'));
+  }
+  return sizeArray;
 }

--- a/src/d3/hapticplot.d3.spec.ts
+++ b/src/d3/hapticplot.d3.spec.ts
@@ -1,5 +1,4 @@
 import { Hapticplot } from './hapticplot.d3';
-import { $ } from 'protractor';
 
 
 describe('VR Haptic Plot', () => {
@@ -57,7 +56,27 @@ describe('VR Haptic Plot', () => {
     const result = getRadius(element, shape);
     expect(result).toEqual(expectedSizeArray);
   });
+
+  it('places points for each element in a three element array, and checks their hoverable property', () => {
+    hapticplot.init(element, [10, 20, 30]);
+    const expectedSizeArray = ['hoverable', 'hoverable', 'hoverable'];
+    const result = getHoverable(element, shape);
+    expect(result).toEqual(expectedSizeArray);
+  });
+
+  it('places points for each element in a three element array, and checks their color after a hover-start event', () => {
+    hapticplot.init(element, [10, 20, 30]);
+    const expectedSizeArray = ['red', 'red', 'red'];
+    const result = getHoveredColor(element, shape);
+    expect(result).toEqual(expectedSizeArray);
+  });
 });
+
+/*
+*
+Helper Functions
+*
+*/
 
 // returns array of actual position vectors
 function getPosition(element: HTMLElement, shape: string): Array<{x: number, y: number, z: number}>{
@@ -69,28 +88,43 @@ function getPosition(element: HTMLElement, shape: string): Array<{x: number, y: 
   return positionArray;
 }
 
-/*
-*
-Helper Functions
-*
-*/
-
 // returns array of each generated objects color
 function getColor(element: HTMLElement, shape: string): Array<string>{
   const childrenArray = element.querySelectorAll(shape);
-  const colorArray: Array<string> = [];
+  const attrArray: Array<string> = [];
   for (const child of (childrenArray as any)){
-    colorArray.push((child as any).getAttribute('color'));
+    attrArray.push((child as any).getAttribute('color'));
   }
-  return colorArray;
+  return attrArray;
 }
 
 // returns array of each generated objects radius
 function getRadius(element: HTMLElement, shape: string): Array<string>{
   const childrenArray = element.querySelectorAll(shape);
-  const sizeArray: Array<string> = [];
+  const attrArray: Array<string> = [];
   for (const child of (childrenArray as any)){
-    sizeArray.push((child as any).getAttribute('radius'));
+    attrArray.push((child as any).getAttribute('radius'));
   }
-  return sizeArray;
+  return attrArray;
+}
+
+// returns array of each generated objects hover property
+function getHoverable(element: HTMLElement, shape: string): Array<string>{
+  const childrenArray = element.querySelectorAll(shape);
+  const attrArray: Array<string> = [];
+  for (const child of (childrenArray as any)){
+    attrArray.push((child as any).components.hoverable.attrName);
+  }
+  return attrArray;
+}
+
+// returns array of each generated objects color, after a hover event has occured
+function getHoveredColor(element: HTMLElement, shape: string): Array<string>{
+  const childrenArray = element.querySelectorAll(shape);
+  const attrArray: Array<string> = [];
+  for (const child of (childrenArray as any)){
+    (child as any).dispatchEvent(new Event('hover-start'));
+    attrArray.push((child as any).getAttribute('color'));
+  }
+  return attrArray;
 }

--- a/src/d3/hapticplot.d3.spec.ts
+++ b/src/d3/hapticplot.d3.spec.ts
@@ -1,86 +1,83 @@
 import { Hapticplot } from './hapticplot.d3';
+import { Entity } from 'aframe';
 
 
 describe('VR Haptic Plot', () => {
   const shape = 'a-sphere';
-  let element: HTMLElement;
+  let scene: HTMLElement;
   let hapticplot: Hapticplot;
 
   beforeEach( () =>  {
-    element = document.createElement('a-scene');
+    scene = document.createElement('a-scene');
     hapticplot = new Hapticplot(shape);
   });
 
-  it('places no points bc 1:1 correspondence with empty element array', () => {
-    hapticplot.init(element, []);
+  it('places no points bc 1:1 correspondence with empty data array', () => {
+    hapticplot.init(scene, []);
     const expectedPosArray = [];
-    const result = getPosition(element, shape);
+    const result = getPosition(scene, shape);
     expect(result).toEqual(expectedPosArray);
   });
 
-  it('places points for each element in a one element array', () => {
-    hapticplot.init(element, [10]);
+  it('places points for each datum in a one datum array', () => {
+    hapticplot.init(scene, [10]);
     const expectedPosArray = [{ x: 0, y: 10, z: -1 }];
-    const result = getPosition(element, shape);
+    const result = getPosition(scene, shape);
     expect(result).toEqual(expectedPosArray);
   });
 
-  it('places points for each element in a two element array', () => {
-    hapticplot.init(element, [10, 10]);
+  it('places points for each datum in a two datum array', () => {
+    hapticplot.init(scene, [10, 10]);
     const expectedPosArray = [{ x: 0, y: 10, z: -1 }, { x: 0.1, y: 10, z: -1 }];
-    const result = getPosition(element, shape);
+    const result = getPosition(scene, shape);
     expect(result).toEqual(expectedPosArray);
   });
 
-  it('places points for each element in a eight element array', () => {
-    hapticplot.init(element, [10, 10, 20, 20, 30, 30, 40, 40]);
+  it('places points for each datum in a eight datum array', () => {
+    hapticplot.init(scene, [10, 10, 20, 20, 30, 30, 40, 40]);
     const expectedPosArray = [
       { x: 0, y: 10, z: -1 }, { x: 0.10, y: 10, z: -1 },
       { x: 0.2, y: 20, z: -1 }, { x: 0.3, y: 20, z: -1 },
       { x: 0.4, y: 30, z: -1 }, { x: 0.5, y: 30, z: -1 },
      { x: 0.6, y: 40, z: -1 }, { x: 0.7, y: 40, z: -1 }];
-    const result = getPosition(element, shape);
+    const result = getPosition(scene, shape);
     expect(result).toEqual(expectedPosArray);
   });
 
-  it('places points for each element in a three element array, and checks their color property', () => {
-    hapticplot.init(element, [10, 20, 30]);
+  it('places points for each datum and sets the correct color property on the resulting shape entities', () => {
+    hapticplot.init(scene, [10, 20, 30]);
     const expectedColorArray = ['green', 'green' , 'green'];
-    const result = getColor(element, shape);
+    const result = getColor(scene, shape);
     expect(result).toEqual(expectedColorArray);
   });
 
-  it('places points for each element in a three element array, and checks their size property', () => {
-    hapticplot.init(element, [10, 20, 30]);
+  it('places points for each datum and sets the correct size property on the resulting shape entities', () => {
+    hapticplot.init(scene, [10, 20, 30]);
     const expectedSizeArray = ['0.05', '0.05', '0.05'];
-    const result = getRadius(element, shape);
+    const result = getRadius(scene, shape);
     expect(result).toEqual(expectedSizeArray);
   });
 
-  it('places points for each element in a three element array, and checks their hoverable property', () => {
-    hapticplot.init(element, [10, 20, 30]);
+  it('places points for each datum and sets the correct hoverable property on the resulting shape entities', () => {
+    hapticplot.init(scene, [10, 20, 30]);
     const expectedSizeArray = ['hoverable', 'hoverable', 'hoverable'];
-    const result = getHoverable(element, shape);
+    const result = getHoverable(scene, shape);
     expect(result).toEqual(expectedSizeArray);
   });
 
-  it('places points for each element in a three element array, and checks their color after a hover-start event', () => {
-    hapticplot.init(element, [10, 20, 30]);
+  it('places points for each datum and sets the correct color property on the resulting shape entities after a hover event', () => {
+    hapticplot.init(scene, [10, 20, 30]);
     const expectedSizeArray = ['red', 'red', 'red'];
-    const result = getHoveredColor(element, shape);
+    const result = getHoveredColor(scene, shape);
     expect(result).toEqual(expectedSizeArray);
   });
 });
 
-/*
-*
-Helper Functions
-*
-*/
+// Helper Functions
 
 // returns array of actual position vectors
-function getPosition(element: HTMLElement, shape: string): Array<{x: number, y: number, z: number}>{
-  const childrenArray = element.querySelectorAll(shape);
+function getPosition(scene: HTMLElement, shape: string): Array<{x: number, y: number, z: number}>{
+  const childrenArray = scene.querySelectorAll(shape);
   const positionArray: Array<{x: number, y: number, z: number}> = [];
   for (const child of (childrenArray as any)){
     positionArray.push((child as any).components.position.attrValue);
@@ -89,42 +86,24 @@ function getPosition(element: HTMLElement, shape: string): Array<{x: number, y: 
 }
 
 // returns array of each generated objects color
-function getColor(element: HTMLElement, shape: string): Array<string>{
-  const childrenArray = element.querySelectorAll(shape);
-  const attrArray: Array<string> = [];
-  for (const child of (childrenArray as any)){
-    attrArray.push((child as any).getAttribute('color'));
-  }
-  return attrArray;
+function getColor(scene: HTMLElement, shape: string): (string | null)[]{
+  return Array.from(scene.querySelectorAll(shape)).map((point: Element) => point.getAttribute('color'));
 }
 
 // returns array of each generated objects radius
-function getRadius(element: HTMLElement, shape: string): Array<string>{
-  const childrenArray = element.querySelectorAll(shape);
-  const attrArray: Array<string> = [];
-  for (const child of (childrenArray as any)){
-    attrArray.push((child as any).getAttribute('radius'));
-  }
-  return attrArray;
+function getRadius(scene: HTMLElement, shape: string): (string | null)[]{
+  return Array.from(scene.querySelectorAll(shape)).map((point: Element) => point.getAttribute('radius'));
 }
 
 // returns array of each generated objects hover property
-function getHoverable(element: HTMLElement, shape: string): Array<string>{
-  const childrenArray = element.querySelectorAll(shape);
-  const attrArray: Array<string> = [];
-  for (const child of (childrenArray as any)){
-    attrArray.push((child as any).components.hoverable.attrName);
-  }
+function getHoverable(scene: HTMLElement, shape: string): (string | undefined)[]{
+  const attrArray: (string | undefined)[] = [];
+  Array.from(scene.querySelectorAll(shape)).forEach((child) => { attrArray.push((child as Entity).components.hoverable.attrName); });
   return attrArray;
 }
 
 // returns array of each generated objects color, after a hover event has occured
-function getHoveredColor(element: HTMLElement, shape: string): Array<string>{
-  const childrenArray = element.querySelectorAll(shape);
-  const attrArray: Array<string> = [];
-  for (const child of (childrenArray as any)){
-    (child as any).dispatchEvent(new Event('hover-start'));
-    attrArray.push((child as any).getAttribute('color'));
-  }
-  return attrArray;
+function getHoveredColor(scene: HTMLElement, shape: string): (string | null)[]{
+  Array.from(scene.querySelectorAll(shape)).forEach((child) => { child.dispatchEvent(new Event('hover-start')); });
+  return Array.from(scene.querySelectorAll(shape)).map((point: Element) => point.getAttribute('color'));
 }

--- a/src/d3/hapticplot.d3.ts
+++ b/src/d3/hapticplot.d3.ts
@@ -18,7 +18,7 @@ export class Hapticplot{
     this.hscale = d3.scaleLinear();
     this.hscale.domain([0, d3.max(this.data) as number])  // max of dataset
       .range([0, 100]);
-    this.setupPoints('blue', 0.1);                        // linear mapping of data set values to values from 0 to 10
+    this.setupPoints('blue', 0.05);                        // linear mapping of data set values to values from 0 to 10
     this.createSky();
     this.createGridPlane();
   }
@@ -52,15 +52,18 @@ export class Hapticplot{
       .attr('dropppable', '')
       // Adds listeners for state change events, which trigger a change in the
       // point's color property when a hover event occurs
-      .on('stateadded',  (d, i, g) => this.modifyColorOnStateChange(g[i], 'hovered', 'orange'))
-      .on('stateremoved',  (d, i, g) => this.modifyColorOnStateChange(g[i], 'hovered', 'green'));
+      .on('hover-start',  (d, i, g) => this.onHoverStart(g[i], 'orange'))
+      .on('hover-end',  (d, i, g) => this.onHoverEnd(g[i], 'green'));
 
   }
 
-  private modifyColorOnStateChange(entity, state , color){
-    if (d3.event.detail === state){
-      d3.select(entity).attr('color', color);
-    }
+  private onHoverStart(entity, color){
+    d3.event.detail.hand.components.haptics.pulse(0.5, 1000)
+    d3.select(entity).attr('color', color);
+  }
+
+  private onHoverEnd(entity, color){
+    d3.select(entity).attr('color', color);
   }
 
   // Generates a world space position for each data entity, based on ingested data

--- a/src/d3/hapticplot.d3.ts
+++ b/src/d3/hapticplot.d3.ts
@@ -50,10 +50,6 @@ export class Hapticplot{
       .attr('radius', size)
       // Enables controller interaction with points using superhands' tags
       .attr('hoverable', '')
-      .attr('grabbable', '')
-      .attr('stretchable', '')
-      .attr('draggable', '')
-      .attr('dropppable', '')
       // Adds listeners for state change events, which trigger a change in the
       // point's color property when a hover event occurs
       .on('hover-start',  (d, i, g) => this.onHoverStart(g[i], d, 'red'))
@@ -77,7 +73,9 @@ export class Hapticplot{
      - triggers a haptic pulse
      - changes the entities color to indicate a pulse has fired
     */
-    d3.event.detail.hand.components.haptics.pulse(hapticIntensity, 1000);
+    if (d3.event.detail !== undefined && d3.event.detail.hand !== undefined){
+      d3.event.detail.hand.components.haptics.pulse(hapticIntensity, 1000);
+    }
     d3.select(entity).attr('color', color);
   }
 

--- a/src/d3/hapticplot.d3.ts
+++ b/src/d3/hapticplot.d3.ts
@@ -50,7 +50,7 @@ export class Hapticplot{
       //    elements & # DOM elements don't match
       .data(this.data).enter().append(this.shape).classed('datapoint', true)
       // Updates points positions based on ingested data
-      .each((d, i , g) => this.generatePositions(d, i, g[i]))
+      .each((d, i , g) => this.setPosition(d, i, g[i]))
       // Adds given color property to all points
       .attr('color', defaultColor)
       // Sets points radius property
@@ -69,7 +69,7 @@ export class Hapticplot{
    * @param data Ingested Data
    * @param index Crrent index in data array
    */
-  private generatePositions(data, index, entity){
+  private setPosition(data, index, entity){
     const x = index / 10;
     const y = data;
     const z = -1;
@@ -99,9 +99,7 @@ export class Hapticplot{
     d3.select(entity).attr('color', defaultColor);
   }
 
-  /**
-   * creates and adds a sky box to the scene
-   */
+  // Creates and adds a sky box to the scene
   private createSky(){
     const aSky = document.createElement('a-sky');
     this.container!.appendChild(aSky);
@@ -110,9 +108,7 @@ export class Hapticplot{
     });
   }
 
-  /**
-   * creates and adds grid 3D grid lines to the scene
-   */
+  // Creates and adds grid 3D grid lines to the scene
   private createGridPlane()
   {
     const xGrid = document.createElement('a-entity');

--- a/src/d3/hapticplot.d3.ts
+++ b/src/d3/hapticplot.d3.ts
@@ -1,5 +1,6 @@
 import * as d3 from 'd3';
 import * as THREE from 'three';
+import { Entity } from 'aframe';
 
 export class Hapticplot{
     private data: number[];
@@ -49,7 +50,7 @@ export class Hapticplot{
       //    elements & # DOM elements don't match
       .data(this.data).enter().append(this.shape).classed('datapoint', true)
       // Updates points positions based on ingested data
-      .attr('position', (d, i) =>  this.generatePositions(d, i))
+      .each((d, i , g) => this.generatePositions(d, i, g[i]))
       // Adds given color property to all points
       .attr('color', defaultColor)
       // Sets points radius property
@@ -68,11 +69,11 @@ export class Hapticplot{
    * @param data Ingested Data
    * @param index Crrent index in data array
    */
-  private generatePositions(data, index){
+  private generatePositions(data, index, entity){
     const x = index / 10;
     const y = data;
     const z = -1;
-    return `${x} ${y} ${z}`;
+    (entity as Entity).object3D.position.set(x, y, z);
   }
 
   /**

--- a/src/d3/hapticplot.d3.ts
+++ b/src/d3/hapticplot.d3.ts
@@ -12,6 +12,10 @@ export class Hapticplot{
   }
 
   init(container: HTMLElement | null, data: number[]){
+    const POINT_SIZE = 0.05;
+    const DEFAULT_COLOR = 'green';
+    const HOVER_COLOR = 'red';
+
     this.data = data;
     this.container = container;
     // create a scale so that there is correspondence between data set and screen render,
@@ -19,24 +23,26 @@ export class Hapticplot{
     this.hscale = d3.scaleLinear();
     this.hscale.domain([0, d3.max(this.data) as number])  // max of dataset
       .range([0, 100]);
-    this.setupPoints('green', 0.05);
+    this.setupPoints(DEFAULT_COLOR, HOVER_COLOR, POINT_SIZE);
     this.createSky();
     this.createGridPlane();
   }
 
-
+  /**
+   * selects all entities of type datapoint
+   */
   private getShapes(){
-    /*
-    selects all entities of type this.shape
-    */
     return d3.select(this.container).selectAll('datapoint');
   }
 
-  private setupPoints(color, size) {
-    /*
-    Generates points in the scene based on initilization data
-      - represented in scene as this.shape type entities
-    */
+  /**
+   * Generates points in the scene based on initilization data
+   *   - represented in scene as this.shape type entities
+   * @param defaultColor Points default color
+   * @param hoverColor Points color when hovered
+   * @param size Size of each point
+   */
+  private setupPoints(defaultColor, hoverColor, size) {
     this.getShapes()
       // Adds points of type this.shape to the scene
       //  - "enter" identifies any DOM elements to be added when # array
@@ -45,52 +51,57 @@ export class Hapticplot{
       // Updates points positions based on ingested data
       .attr('position', (d, i) =>  this.generatePositions(d, i))
       // Adds given color property to all points
-      .attr('color', color)
+      .attr('color', defaultColor)
       // Sets points radius property
       .attr('radius', size)
       // Enables controller interaction with points using superhands' tags
       .attr('hoverable', '')
       // Adds listeners for state change events, which trigger a change in the
       // point's color property when a hover event occurs
-      .on('hover-start',  (d, i, g) => this.onHoverStart(g[i], d, 'red'))
-      .on('hover-end',  (d, i, g) => this.onHoverEnd(g[i], 'green'));
+      .on('hover-start',  (d, i, g) => this.onHoverStart(g[i], d, hoverColor))
+      .on('hover-end',  (d, i, g) => this.onHoverEnd(g[i], defaultColor));
 
   }
 
+  /**
+   * Generates a world space position for each data entity, based on ingested data
+   * @param data Ingested Data
+   * @param index Crrent index in data array
+   */
   private generatePositions(data, index){
-    /*
-      Generates a world space position for each data entity, based on ingested data
-    */
     const x = index / 10;
     const y = data;
     const z = -1;
     return `${x} ${y} ${z}`;
   }
 
-  private onHoverStart(entity, hapticIntensity, color){
-    /*
-    When an object begins being hovered by the controller entity
-     - triggers a haptic pulse
-     - changes the entities color to indicate a pulse has fired
-    */
-    if (d3.event.detail !== undefined && d3.event.detail.hand !== undefined){
-      d3.event.detail.hand.components.haptics.pulse(hapticIntensity, 1000);
-    }
-    d3.select(entity).attr('color', color);
+  /**
+   * When a data entity begins being hovered by the controller entity
+   *  - triggers a haptic pulse
+   *  - changes the entities color to indicate a pulse has fired
+   * @param entity The entity being hovered
+   * @param hapticIntensity A points haptic intensity, based on is associated data
+   * @param hoverColor The colorthe entity takes on while hoverec
+   */
+  private onHoverStart(entity, hapticIntensity, hoverColor){
+    d3.event.detail?.hand?.components.haptics.pulse(hapticIntensity, 1000);
+    d3.select(entity).attr('color', hoverColor);
   }
 
-  private onHoverEnd(entity, color){
-    /*
-    When an object stops being hovered by the controller entity
-     - changes the entities color to indicate hovering has ended
-    */
-    d3.select(entity).attr('color', color);
+  /**
+   * When an object stops being hovered by the controller entity
+   *  - changes the entities color to indicate hovering has ended
+   * @param entity The data entity which is no longer hovered
+   * @param defaultColor The default color of unhovered entities
+   */
+  private onHoverEnd(entity, defaultColor){
+    d3.select(entity).attr('color', defaultColor);
   }
 
+  /**
+   * creates and adds a sky box to the scene
+   */
   private createSky(){
-    /*
-    creates and adds a sky box to the scene
-    */
     const aSky = document.createElement('a-sky');
     this.container!.appendChild(aSky);
     d3.select(this.container).selectAll('a-sky').attr('color', () => {
@@ -98,11 +109,11 @@ export class Hapticplot{
     });
   }
 
+  /**
+   * creates and adds grid 3D grid lines to the scene
+   */
   private createGridPlane()
   {
-    /*
-    creates and adds grid 3D grid lines to the scene
-    */
     const xGrid = document.createElement('a-entity');
     xGrid.id = 'xGrid';
     this.container!.appendChild(xGrid);

--- a/src/d3/hapticplot.d3.ts
+++ b/src/d3/hapticplot.d3.ts
@@ -14,17 +14,21 @@ export class Hapticplot{
   init(container: HTMLElement | null, data: number[]){
     this.data = data;
     this.container = container;
-    // create a scale so that there is correspondence between data set and screen render
+    // create a scale so that there is correspondence between data set and screen render,
+    // a linear mapping of data set values to values from 0 to 10
     this.hscale = d3.scaleLinear();
     this.hscale.domain([0, d3.max(this.data) as number])  // max of dataset
       .range([0, 100]);
-    this.setupPoints('blue', 0.05);                        // linear mapping of data set values to values from 0 to 10
+    this.setupPoints('green', 0.05);
     this.createSky();
     this.createGridPlane();
   }
 
-  // selects all entities of type this.shape
+
   private getShapes(){
+    /*
+    selects all entities of type this.shape
+    */
     return d3.select(this.container).selectAll('datapoint');
   }
 
@@ -52,26 +56,37 @@ export class Hapticplot{
       .attr('dropppable', '')
       // Adds listeners for state change events, which trigger a change in the
       // point's color property when a hover event occurs
-      .on('hover-start',  (d, i, g) => this.onHoverStart(g[i], 'orange'))
+      .on('hover-start',  (d, i, g) => this.onHoverStart(g[i], d, 'red'))
       .on('hover-end',  (d, i, g) => this.onHoverEnd(g[i], 'green'));
 
   }
 
-  private onHoverStart(entity, color){
-    d3.event.detail.hand.components.haptics.pulse(0.5, 1000)
-    d3.select(entity).attr('color', color);
-  }
-
-  private onHoverEnd(entity, color){
-    d3.select(entity).attr('color', color);
-  }
-
-  // Generates a world space position for each data entity, based on ingested data
   private generatePositions(data, index){
+    /*
+      Generates a world space position for each data entity, based on ingested data
+    */
     const x = index / 10;
     const y = data;
     const z = -1;
     return `${x} ${y} ${z}`;
+  }
+
+  private onHoverStart(entity, hapticIntensity, color){
+    /*
+    When an object begins being hovered by the controller entity
+     - triggers a haptic pulse
+     - changes the entities color to indicate a pulse has fired
+    */
+    d3.event.detail.hand.components.haptics.pulse(hapticIntensity, 1000);
+    d3.select(entity).attr('color', color);
+  }
+
+  private onHoverEnd(entity, color){
+    /*
+    When an object stops being hovered by the controller entity
+     - changes the entities color to indicate hovering has ended
+    */
+    d3.select(entity).attr('color', color);
   }
 
   private createSky(){


### PR DESCRIPTION
Adds a d3 function to set up haptic triggers on generated data objects. 
 - Replaces `modifyOnStateChange` function with `onHoverStart` and `onHoverEnd`
 - Adds triggers to fire haptic pulses when a `hover-start` event is emitted by a data object
 - Accesses the controller entity through the `event.details.hand` property
 - Initializes controller entities' haptic component force property with value 0 (when the `.pulse` method is called, it triggers a pulse with the initialization force value + the passed value, and the default initialization is the max. Setting it to 0 allows the passed value to control the haptics)  
