### PR TITLE
Fix undeterministic test failure

### DIFF
--- a/src/services/data/data.service.ts
+++ b/src/services/data/data.service.ts
@@ -45,6 +45,7 @@ export class DataService implements OnDestroy {
       .pipe(distinctUntilChanged((prev, curr) => prev.name === curr.name))
       .pipe(pluck('name'))
       .pipe(map(name => name ?? Object.keys(datasets)[0]))
+      .pipe(filter(name => name in datasets))
       .subscribe(name => {
         const meta = {
           enabled: {


### PR DESCRIPTION
Found out it was caused by one of the tests feeding `'INVALID_DATASET_NAME'` as dataset name.

The test has always been throwing an error, but Jasmine ignored the error depending on the randomized order of running tests, which made it undeterministically succeeded.

https://github.com/googleinterns/guide-doge/blob/3a79f33fad0066751b90477b8b0d5fe7ca0d6c34/src/services/data/data.service.spec.ts#L45
