### PR TITLE
Adds controller mock and haptic initialization testing

### DIFF
--- a/src/d3/hapticplot.d3.spec.ts
+++ b/src/d3/hapticplot.d3.spec.ts
@@ -75,7 +75,7 @@ describe('VR Haptic Plot', () => {
 
   it('initilizes the controller entitys and attaches the haptic component', () => {
     const expectedRes = true;
-    const result = getHaptics(controller);
+    const result = hasHaptics(controller);
     expect(result).toEqual(expectedRes);
   });
 });
@@ -84,15 +84,10 @@ describe('VR Haptic Plot', () => {
 
 // Returns an array of actual position vectors
 function getPositions(scene: HTMLElement, shape: string): Vector3[]{
-  const attrArray: Vector3[] = [];
-  const shapes = scene.querySelectorAll(shape);
-  for (const point of shapes){
-    attrArray.push(new Vector3(
-      (point as Entity).object3D.position.x,
-      (point as Entity).object3D.position.y,
-      (point as Entity).object3D.position.z));
-  }
-  return attrArray;
+  return Array.from(scene.querySelectorAll(shape)).map((point: Element) => new Vector3(
+    (point as Entity).object3D.position.x,
+    (point as Entity).object3D.position.y,
+    (point as Entity).object3D.position.z));
 }
 
 // Returns an array of each generated objects color
@@ -120,6 +115,6 @@ function getHoveredColor(scene: HTMLElement, shape: string): (string | null)[]{
 }
 
 // Checks the given controller for a haptic component
-function getHaptics(controller: HTMLElement): boolean{
+function hasHaptics(controller: HTMLElement): boolean{
   return (controller as Entity).components.hasOwnProperty('haptics');
 }

--- a/src/d3/hapticplot.d3.spec.ts
+++ b/src/d3/hapticplot.d3.spec.ts
@@ -86,7 +86,7 @@ describe('VR Haptic Plot', () => {
 function getPositions(scene: HTMLElement, shape: string): Vector3[]{
   const attrArray: Vector3[] = [];
   const shapes = scene.querySelectorAll(shape);
-  for (const point of Array.from(shapes)){
+  for (const point of shapes){
     attrArray.push(new Vector3(
       (point as Entity).object3D.position.x,
       (point as Entity).object3D.position.y,
@@ -113,7 +113,7 @@ function getHoverable(scene: HTMLElement, shape: string): (string | undefined)[]
 // Returns an array of each generated objects color, after a hover event has occured
 function getHoveredColor(scene: HTMLElement, shape: string): (string | null)[]{
   const shapes = scene.querySelectorAll(shape);
-  for (const point of Array.from(shapes)){
+  for (const point of shapes){
     point.dispatchEvent(new Event('hover-start'));
   }
   return Array.from(scene.querySelectorAll(shape)).map((point: Element) => point.getAttribute('color'));

--- a/src/d3/hapticplot.d3.spec.ts
+++ b/src/d3/hapticplot.d3.spec.ts
@@ -1,89 +1,107 @@
 import { Hapticplot } from './hapticplot.d3';
-import { Entity } from 'aframe';
+import { Entity, Scene } from 'aframe';
 import { Vector3 } from 'three';
+import 'aframe-extras';
+import 'super-hands';
+import 'aframe-haptics-component';
 
 
 describe('VR Haptic Plot', () => {
   const shape = 'a-sphere';
   let scene: HTMLElement;
+  let controller: HTMLElement;
   let hapticplot: Hapticplot;
 
   beforeEach( () =>  {
     scene = document.createElement('a-scene');
+    controller = document.createElement('a-entity');
+    controller.setAttribute('sphere-collider', '');
+    controller.setAttribute('super-hands', '');
+    controller.setAttribute('oculus-touch-controls', 'hand: left');
+    controller.setAttribute('haptics', 'force: 0');
+    (controller as Entity).sceneEl = (scene as Scene);
+    scene.appendChild(controller);
     hapticplot = new Hapticplot(shape);
   });
 
   it('places no points bc 1:1 correspondence with empty data array', () => {
     hapticplot.init(scene, []);
     const expectedPosArray = [];
-    const result = getPosition(scene, shape);
+    const result = getPositions(scene, shape);
     expect(result).toEqual(expectedPosArray);
   });
 
   it('places points for each datum in a one datum array', () => {
     hapticplot.init(scene, [10]);
     const expectedPosArray = [new Vector3(0, 10, -1)];
-    const result = getPosition(scene, shape);
+    const result = getPositions(scene, shape);
     expect(result).toEqual(expectedPosArray);
   });
 
   it('places points for each datum in a three datum array', () => {
     hapticplot.init(scene, [0, 10, 20]);
     const expectedPosArray = [new Vector3(0, 0, -1), new Vector3(0.1, 10, -1), new Vector3(0.2, 20, -1)];
-    const result = getPosition(scene, shape);
+    const result = getPositions(scene, shape);
     expect(result).toEqual(expectedPosArray);
   });
 
   it('places points for each datum and sets the correct color property on the resulting shape entities', () => {
     hapticplot.init(scene, [10, 20, 30]);
     const expectedColorArray = ['green', 'green' , 'green'];
-    const result = getColor(scene, shape);
+    const result = getColors(scene, shape);
     expect(result).toEqual(expectedColorArray);
   });
 
   it('places points for each datum and sets the correct size property on the resulting shape entities', () => {
     hapticplot.init(scene, [10, 20, 30]);
     const expectedSizeArray = ['0.05', '0.05', '0.05'];
-    const result = getRadius(scene, shape);
+    const result = getRadii(scene, shape);
     expect(result).toEqual(expectedSizeArray);
   });
 
   it('places points for each datum and sets the correct hoverable property on the resulting shape entities', () => {
     hapticplot.init(scene, [10, 20, 30]);
-    const expectedSizeArray = ['hoverable', 'hoverable', 'hoverable'];
+    const expectedAttrArray = ['hoverable', 'hoverable', 'hoverable'];
     const result = getHoverable(scene, shape);
-    expect(result).toEqual(expectedSizeArray);
+    expect(result).toEqual(expectedAttrArray);
   });
 
   it('places points for each datum and sets the correct color property on the resulting shape entities after a hover event', () => {
     hapticplot.init(scene, [10, 20, 30]);
-    const expectedSizeArray = ['red', 'red', 'red'];
+    const expectedAttrArray = ['red', 'red', 'red'];
     const result = getHoveredColor(scene, shape);
-    expect(result).toEqual(expectedSizeArray);
+    expect(result).toEqual(expectedAttrArray);
+  });
+
+  it('initilizes the controller entitys and attaches the haptic component', () => {
+    const expectedRes = true;
+    const result = getHaptics(controller);
+    expect(result).toEqual(expectedRes);
   });
 });
 
 // Helper Functions
 
 // Returns an array of actual position vectors
-function getPosition(scene: HTMLElement, shape: string): Vector3[]{
+function getPositions(scene: HTMLElement, shape: string): Vector3[]{
   const attrArray: Vector3[] = [];
-  Array.from(scene.querySelectorAll(shape)).forEach((child) => {
+  const shapes = scene.querySelectorAll(shape);
+  for (const point of Array.from(shapes)){
     attrArray.push(new Vector3(
-      (child as Entity).object3D.position.x,
-      (child as Entity).object3D.position.y,
-      (child as Entity).object3D.position.z));
-  });
+      (point as Entity).object3D.position.x,
+      (point as Entity).object3D.position.y,
+      (point as Entity).object3D.position.z));
+  }
   return attrArray;
 }
 
 // Returns an array of each generated objects color
-function getColor(scene: HTMLElement, shape: string): (string | null)[]{
+function getColors(scene: HTMLElement, shape: string): (string | null)[]{
   return Array.from(scene.querySelectorAll(shape)).map((point: Element) => point.getAttribute('color'));
 }
 
 // Returns an array of each generated objects radius
-function getRadius(scene: HTMLElement, shape: string): (string | null)[]{
+function getRadii(scene: HTMLElement, shape: string): (string | null)[]{
   return Array.from(scene.querySelectorAll(shape)).map((point: Element) => point.getAttribute('radius'));
 }
 
@@ -99,4 +117,9 @@ function getHoveredColor(scene: HTMLElement, shape: string): (string | null)[]{
     point.dispatchEvent(new Event('hover-start'));
   }
   return Array.from(scene.querySelectorAll(shape)).map((point: Element) => point.getAttribute('color'));
+}
+
+// Checks the given controller for a haptic component
+function getHaptics(controller: HTMLElement): boolean{
+  return (controller as Entity).components.hasOwnProperty('haptics');
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "target": "es2015",
     "lib": [
       "es2019",
-      "dom"
+      "dom",
+      "dom.iterable"
     ],
     "strictNullChecks": true,
     "strictFunctionTypes": true,


### PR DESCRIPTION
Adds a mock controller to the testing setup, and attaches relevant components. 
- Implements a `getHaptics` helper function to check that the haptic component attaches successfully to the controller mock.
- Removes use of forEach in the `getPositions` helper function.
- Renames helper functions to better reflect their effects.