### PR TITLE
Load a11y modules only when enabled

### DIFF
--- a/src/components/a11y-host/a11y-host.component.ts
+++ b/src/components/a11y-host/a11y-host.component.ts
@@ -11,7 +11,7 @@ export abstract class A11yHostComponent {
     elementRef.nativeElement[A11yHostComponent.componentKey] = this;
   }
 
-  static getComponent(elementRef) {
+  static getComponent(elementRef): A11yHostComponent {
     return elementRef.nativeElement[A11yHostComponent.componentKey];
   }
 }

--- a/src/components/chart-summarization/chart-summarization.importer.ts
+++ b/src/components/chart-summarization/chart-summarization.importer.ts
@@ -1,4 +1,10 @@
-export async function importSummarizationModule() {
-  const { ChartSummarizationModule } = await import('./chart-summarization.module');
-  return ChartSummarizationModule;
-}
+import { A11yModuleImporter } from '../../directives/a11y/a11y.directive';
+
+export const summarizationModuleImporter: A11yModuleImporter = {
+  preferenceKey: 'summarization$',
+
+  async import() {
+    const { ChartSummarizationModule } = await import('./chart-summarization.module');
+    return ChartSummarizationModule;
+  },
+};

--- a/src/components/chart-summarization/chart-summarization.module.ts
+++ b/src/components/chart-summarization/chart-summarization.module.ts
@@ -2,7 +2,6 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ChartSummarizationComponent } from './chart-summarization.component';
 import { LazyA11yModule } from '../../directives/a11y/a11y.directive';
-import { PreferenceService } from '../../services/preference/preference.service';
 
 @NgModule({
   declarations: [
@@ -17,5 +16,4 @@ import { PreferenceService } from '../../services/preference/preference.service'
 })
 export class ChartSummarizationModule implements LazyA11yModule<ChartSummarizationComponent> {
   A11yComponent = ChartSummarizationComponent;
-  preferenceKey: keyof PreferenceService = 'summarization$';
 }

--- a/src/components/geo-map-navigation/geo-map-navigation.importer.ts
+++ b/src/components/geo-map-navigation/geo-map-navigation.importer.ts
@@ -1,4 +1,10 @@
-export async function importGeoMapNavigationModule() {
-  const { GeoMapNavigationModule } = await import('./geo-map-navigation.module');
-  return GeoMapNavigationModule;
-}
+import { A11yModuleImporter } from '../../directives/a11y/a11y.directive';
+
+export const geoMapNavigationModuleImporter: A11yModuleImporter = {
+  preferenceKey: 'geoMapNavigation$',
+
+  async import() {
+    const { GeoMapNavigationModule } = await import('./geo-map-navigation.module');
+    return GeoMapNavigationModule;
+  },
+};

--- a/src/components/geo-map-navigation/geo-map-navigation.module.ts
+++ b/src/components/geo-map-navigation/geo-map-navigation.module.ts
@@ -2,7 +2,6 @@ import { NgModule } from '@angular/core';
 import { GeoMapNavigationComponent } from './geo-map-navigation.component';
 import { CommonModule } from '@angular/common';
 import { ScreenReaderModule } from '../screen-reader/screen-reader.module';
-import { PreferenceService } from '../../services/preference/preference.service';
 import { LazyA11yModule } from '../../directives/a11y/a11y.directive';
 
 @NgModule({
@@ -19,5 +18,4 @@ import { LazyA11yModule } from '../../directives/a11y/a11y.directive';
 })
 export class GeoMapNavigationModule implements LazyA11yModule<GeoMapNavigationComponent> {
   A11yComponent = GeoMapNavigationComponent;
-  preferenceKey: keyof PreferenceService = 'geoMapNavigation$';
 }

--- a/src/components/line-chart-audification/line-chart-audification.importer.ts
+++ b/src/components/line-chart-audification/line-chart-audification.importer.ts
@@ -1,4 +1,10 @@
-export async function importAudificationModule() {
-  const { LineChartAudificationModule } = await import('./line-chart-audification.module');
-  return LineChartAudificationModule;
-}
+import { A11yModuleImporter } from '../../directives/a11y/a11y.directive';
+
+export const audificationModuleImporter: A11yModuleImporter = {
+  preferenceKey: 'audification$',
+
+  async import() {
+    const { LineChartAudificationModule } = await import('./line-chart-audification.module');
+    return LineChartAudificationModule;
+  },
+};

--- a/src/components/line-chart-audification/line-chart-audification.module.ts
+++ b/src/components/line-chart-audification/line-chart-audification.module.ts
@@ -2,7 +2,6 @@ import { NgModule } from '@angular/core';
 import { LineChartAudificationComponent } from './line-chart-audification.component';
 import { CommonModule } from '@angular/common';
 import { ScreenReaderModule } from '../screen-reader/screen-reader.module';
-import { PreferenceService } from '../../services/preference/preference.service';
 import { LazyA11yModule } from '../../directives/a11y/a11y.directive';
 
 @NgModule({
@@ -19,5 +18,4 @@ import { LazyA11yModule } from '../../directives/a11y/a11y.directive';
 })
 export class LineChartAudificationModule implements LazyA11yModule<LineChartAudificationComponent> {
   A11yComponent = LineChartAudificationComponent;
-  preferenceKey: keyof PreferenceService = 'audification$';
 }

--- a/src/datasets/metas/geo-map.meta.ts
+++ b/src/datasets/metas/geo-map.meta.ts
@@ -1,7 +1,7 @@
 import { DataMeta, MetaType } from './types';
 import { GeoQuery } from '../queries/geo.query';
 import { World } from '../geo.types';
-import { importGeoMapNavigationModule } from '../../components/geo-map-navigation/geo-map-navigation.importer';
+import { geoMapNavigationModuleImporter } from '../../components/geo-map-navigation/geo-map-navigation.importer';
 
 export interface GeoMapMeta extends DataMeta<MetaType.GEO_MAP, GeoQuery> {
   world: World;
@@ -18,7 +18,7 @@ export function createGeoMapMeta(
     queryData,
     world,
     a11yModuleImporters: [
-      importGeoMapNavigationModule,
+      geoMapNavigationModuleImporter,
     ],
   };
 }

--- a/src/datasets/metas/line-chart.meta.ts
+++ b/src/datasets/metas/line-chart.meta.ts
@@ -1,8 +1,8 @@
 import { TimeSeriesQuery } from '../queries/time-series.query';
 import { LegendItemStyle as LineChartLegendItemStyle } from '../../d3/line-chart.d3';
 import { MetaType, XYChartMeta } from './types';
-import { importAudificationModule } from '../../components/line-chart-audification/line-chart-audification.importer';
-import { importSummarizationModule } from '../../components/chart-summarization/chart-summarization.importer';
+import { audificationModuleImporter } from '../../components/line-chart-audification/line-chart-audification.importer';
+import { summarizationModuleImporter } from '../../components/chart-summarization/chart-summarization.importer';
 
 export type LineChartMeta = XYChartMeta<MetaType.LINE_CHART, TimeSeriesQuery<LineChartLegendItemStyle>>;
 
@@ -15,8 +15,8 @@ export function createLineChartMeta(
     title,
     queryData,
     a11yModuleImporters: [
-      importAudificationModule,
-      importSummarizationModule,
+      audificationModuleImporter,
+      summarizationModuleImporter,
     ],
   };
 }

--- a/src/datasets/metas/types.ts
+++ b/src/datasets/metas/types.ts
@@ -2,13 +2,12 @@ import { LineChartMeta } from './line-chart.meta';
 import { TabbedChartsMeta } from './tabbed-charts.meta';
 import { VRScatterplotMeta } from './vr-scatter-plot.meta';
 import { GeoMapMeta } from './geo-map.meta';
-import { Type } from '@angular/core';
-import { LazyA11yModule } from '../../directives/a11y/a11y.directive';
+import { A11yModuleImporter } from '../../directives/a11y/a11y.directive';
 
 export interface BaseMeta<T extends MetaType> {
   type: T;
   title: string;
-  a11yModuleImporters?: (() => Promise<Type<LazyA11yModule>>)[];
+  a11yModuleImporters?: A11yModuleImporter[];
 }
 
 export interface DataMeta<T extends MetaType, QueryT> extends BaseMeta<T> {

--- a/src/directives/a11y/a11y.directive.spec.ts
+++ b/src/directives/a11y/a11y.directive.spec.ts
@@ -5,8 +5,9 @@ import { A11yModule } from './a11y.module';
 import { LineChartComponent } from '../../components/line-chart/line-chart.component';
 import { PreferenceService } from '../../services/preference/preference.service';
 import { LineChartModule } from '../../components/line-chart/line-chart.module';
-import { importAudificationModule } from '../../components/line-chart-audification/line-chart-audification.importer';
-import { importSummarizationModule } from '../../components/chart-summarization/chart-summarization.importer';
+import { audificationModuleImporter } from '../../components/line-chart-audification/line-chart-audification.importer';
+import { summarizationModuleImporter } from '../../components/chart-summarization/chart-summarization.importer';
+import { waitFor } from '../../utils/misc';
 
 describe('A11yDirective', () => {
   @Component({
@@ -55,7 +56,7 @@ describe('A11yDirective', () => {
   });
 
   it('should attach or detach an a11y component as the preference changes.', async () => {
-    directive.a11yModuleImporters = [importAudificationModule, importSummarizationModule];
+    directive.a11yModuleImporters = [audificationModuleImporter, summarizationModuleImporter];
     await directive.ngOnInit();
 
     const audificationPreference = preferenceService.audification$.value;
@@ -65,6 +66,8 @@ describe('A11yDirective', () => {
       enabled: true,
     });
     expect(directive.attach).toHaveBeenCalled();
+
+    await waitFor(300);
 
     spyOn(directive, 'detach');
     preferenceService.audification$.next({


### PR DESCRIPTION
Previous refactoring mistakenly made a11y modules to be loaded regardless of whether they are enabled or not.