### PR TITLE
Haptic Guidance

### DIFF
--- a/src/aframe_components/custom-components.ts
+++ b/src/aframe_components/custom-components.ts
@@ -1,0 +1,87 @@
+import { Vector3 } from 'three';
+import { Component } from 'aframe';
+
+const HAPTIC_RANGE = 0.3;
+const COLLISION_DISTANCE = 0.029;
+const HAPTIC_EXPONENT = 2;
+const HAPTIC_GROWTH_MODIFIER = 4;
+const HAPTIC_DURATION = 5000;
+const INTERVAL_DURATION = 100;
+
+interface State {
+  currInterval: number;
+  currPosition: Vector3;
+  distances: Vector3[];
+  currDistance: number;
+  currDistanceScaled: number;
+  intensity: number;
+}
+
+export interface Guidance extends Component {
+  state: State;
+  pointPositions: Vector3[];
+}
+
+export const guideComponent: Partial<Guidance> = {
+  state: {
+    currInterval: INTERVAL_DURATION,
+    currPosition: new Vector3(0, 0, 0),
+    distances: [],
+    currDistance: HAPTIC_RANGE,
+    currDistanceScaled: (HAPTIC_RANGE - COLLISION_DISTANCE) * (HAPTIC_RANGE) / (HAPTIC_RANGE - COLLISION_DISTANCE),
+    intensity: 0,
+  },
+
+  pointPositions: [],
+
+  init(){
+    this.pointPositions =
+      Array.from((this.el.sceneEl.querySelectorAll('a-sphere') as Element[])).map((point: Element) =>
+      point.getAttribute('position'));
+    this.state.currInterval = INTERVAL_DURATION;
+  },
+
+  /**
+   * A function called each render frame which handles the controller haptics
+   * - increases haptic intensity as controller nears a datapoint within HAPTIC_RANGE
+   * - sends hapic pules on a repeating interval once contact is made with a point
+   * @param time global scene uptime
+   * @param timeDelta time elapsed since previous frame
+   */
+  tick(time, timeDelta) {
+    this.state.currPosition = this.el.object3D.position;
+    this.state.distances = Array.from(this.pointPositions as Vector3[]).map((pos: Vector3) => this.state.currPosition.distanceTo(pos));
+    this.state.distances.sort();
+    this.state.currDistance = this.state.distances[0];
+    // If a datapoint is within haptic range, send haptic feedback based on its proximity
+    // - uses a combination of quadratic functions to map proximity to haptic intensity
+    if (COLLISION_DISTANCE < this.state.currDistance && this.state.currDistance < HAPTIC_RANGE){
+      // Translates distance from COLLISION_DISTANCE -> HAPTIC_RANGE to 0 -> HAPTIC_RANGE, for use in intensity calculations
+      this.state.currDistanceScaled = (this.state.currDistance - COLLISION_DISTANCE) * (HAPTIC_RANGE) / (HAPTIC_RANGE - COLLISION_DISTANCE);
+      this.state.intensity = Math.max(
+        Math.pow((this.state.currDistanceScaled - HAPTIC_RANGE) / (HAPTIC_RANGE * 2), HAPTIC_EXPONENT),
+        Math.pow((this.state.currDistanceScaled - HAPTIC_RANGE) / HAPTIC_RANGE, HAPTIC_EXPONENT * HAPTIC_GROWTH_MODIFIER));
+    }
+    // If the controller is touching a data point, fire haptics in an on-off sequence of duration INTERVAL_DURATION
+    // - uses timeDelta to maintain interval consistency between frame refresh rate changes
+    else if (this.state.currDistance <= COLLISION_DISTANCE){
+      this.state.currInterval -= timeDelta;
+      if (this.state.currInterval > INTERVAL_DURATION / 2){
+        this.state.intensity = 1;
+      }
+      else {
+        this.state.intensity = 0;
+      }
+
+      if (this.state.currInterval <= 0){
+        this.state.currInterval = INTERVAL_DURATION;
+      }
+    }
+    else {
+      this.state.intensity = 0;
+    }
+    if (this.el.components?.haptics?.hasOwnProperty('data')){
+      this.el.components.haptics.pulse(this.state.intensity, HAPTIC_DURATION);
+    }
+  }
+};

--- a/src/components/vr-accessibility/vr-accessibility.component.html
+++ b/src/components/vr-accessibility/vr-accessibility.component.html
@@ -1,4 +1,4 @@
-<!-- Creates an embedded scene element.
+<!-- Creates an embedded a-frame virtual reality scene element.
   - sets up controller tracking, models, and haptics.
   -places an interactable box object in the scene
 -->
@@ -6,7 +6,9 @@
   <a-assets></a-assets>
   <a-entity>
     <a-camera></a-camera>
-    <a-entity sphere-collider super-hands oculus-touch-controls="hand: left;" haptics="force: 0"></a-entity>
-    <a-entity sphere-collider super-hands oculus-touch-controls="hand: right;" haptics="force: 0"></a-entity>
+    <a-entity guide sphere-collider="radius: 0.001;" super-hands oculus-touch-controls="hand: left;" haptics="force: 0"></a-entity>
+    <a-entity guide sphere-collider="radius: 0.001;" super-hands oculus-touch-controls="hand: right;" haptics="force: 0"></a-entity>
   </a-entity>
 </a-scene>
+
+

--- a/src/d3/hapticplot.d3.ts
+++ b/src/d3/hapticplot.d3.ts
@@ -3,11 +3,12 @@ import * as THREE from 'three';
 import { Entity } from 'aframe';
 import { sanitizeUrl } from '@braintree/sanitize-url';
 
-const POINT_SIZE = 0.01;
+const POINT_SIZE = 0.02;
 const DEFAULT_COLOR = '#F0A202';
 const HOVER_COLOR = 'red';
 const SKY_COLOR = '#4d4d4d';
 const ASSETS_FOLDER = 'assets/marimbaNotes/';
+const GRAPH_SIZE = 1.4;
 
 export class Hapticplot{
     private data: number[];
@@ -27,7 +28,7 @@ export class Hapticplot{
     // Creates a linear mapping from this.data to graph positions, haptic intensities, and audio selection
     this.graphScale = d3.scaleLinear()
       .domain([0, d3.max(this.data) as number])  // max of dataset
-      .range([0, 0.5]);
+      .range([0, GRAPH_SIZE / 2]);
     this.hapticScale = d3.scaleLinear()
       .domain([0, d3.max(this.data) as number])  // max of dataset
       .range([0, 1]);
@@ -83,9 +84,9 @@ export class Hapticplot{
    * @param point the point whos position is being set
    */
   private setPosition(datum, index, point){
-    const x = (0.5 / this.data.length) * index;
+    const x = ((GRAPH_SIZE / 2) / this.data.length) * index;
     const y = this.graphScale(datum) + 1;
-    const z = -1;
+    const z = -GRAPH_SIZE / 4;
     (point as Entity).object3D.position.set(x, y, z);
   }
 
@@ -108,10 +109,11 @@ export class Hapticplot{
    * @param size The radius of the point being hovered
    */
   private onHoverStart(point, hapticIntensity, hoverColor, size){
-    d3.event.detail?.hand?.components.haptics.pulse(hapticIntensity, 5000);
     d3.select(point)
-      .attr('color', hoverColor)
-      .attr('radius', size + (hapticIntensity / 60));
+      .attr('color', hoverColor);
+    if (point.components?.sound?.isPlaying){
+      point.components.sound.stopSound();
+    }
   }
 
   /**
@@ -121,10 +123,8 @@ export class Hapticplot{
    * @param size The radius of the point no longer being hovered
    */
   private onHoverEnd(point, defaultColor, size){
-    d3.event.detail?.hand?.components.haptics.pulse(0, 1);
     d3.select(point)
-      .attr('color', defaultColor)
-      .attr('radius', size);
+      .attr('color', defaultColor);
   }
 
   /**
@@ -144,25 +144,25 @@ export class Hapticplot{
     const xGrid = document.createElement('a-entity');
     xGrid.id = 'xGrid';
     this.container!.appendChild(xGrid);
-    xGrid.object3D.add(new THREE.GridHelper(1, 50, 0xffffff, 0xffffff));
+    xGrid.object3D.add(new THREE.GridHelper(GRAPH_SIZE, 50, 0xffffff, 0xffffff));
     d3.select(this.container).select('#xGrid')
-      .attr('position', '0 1 -1')
+      .attr('position', `0 1 -${GRAPH_SIZE / 4}`)
       .attr('rotation', '0 0 0');
 
     const yGrid = document.createElement('a-entity');
     yGrid.id = 'yGrid';
     this.container!.appendChild(yGrid);
-    yGrid.object3D.add(new THREE.GridHelper(1, 50, 0xffffff, 0xffffff));
+    yGrid.object3D.add(new THREE.GridHelper(GRAPH_SIZE, 50, 0xffffff, 0xffffff));
     d3.select(this.container).select('#yGrid')
-      .attr('position', '0 1 -1')
+      .attr('position', `0 1 -${GRAPH_SIZE / 4}`)
       .attr('rotation', '0 0 -90');
 
     const zGrid = document.createElement('a-entity');
     zGrid.id = 'zGrid';
     this.container!.appendChild(zGrid);
-    zGrid.object3D.add(new THREE.GridHelper(1, 50, 0xffffff, 0xffffff));
+    zGrid.object3D.add(new THREE.GridHelper(GRAPH_SIZE, 50, 0xffffff, 0xffffff));
     d3.select(this.container).select('#zGrid')
-      .attr('position', '0 1 -1')
+      .attr('position', `0 1 -${GRAPH_SIZE / 4}`)
       .attr('rotation', '-90 0 0');
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { environment } from './environments/environment';
 import { AppModule } from './app.module';
+import { guideComponent } from './aframe_components/custom-components';
 
 if (environment.production) {
   enableProdMode();
@@ -9,3 +10,6 @@ if (environment.production) {
 
 platformBrowserDynamic().bootstrapModule(AppModule)
   .catch(err => console.error(err));
+
+// Register custom aframe components
+AFRAME.registerComponent('guide', guideComponent);

--- a/src/test.ts
+++ b/src/test.ts
@@ -3,6 +3,7 @@
 import 'zone.js/dist/zone-testing';
 import { getTestBed } from '@angular/core/testing';
 import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+import { guideComponent } from './aframe_components/custom-components';
 
 declare const require: {
   context(path: string, deep?: boolean, filter?: RegExp): {
@@ -20,3 +21,6 @@ getTestBed().initTestEnvironment(
 const context = require.context('./', true, /\.spec\.ts$/);
 // And load the modules.
 context.keys().map(context);
+
+// Register custom aframe components
+AFRAME.registerComponent('guide', guideComponent);


### PR DESCRIPTION
This update adds Haptic Guidance for data point navigation, and support for repeat sound triggers.

Haptic:
- A custom a-frame component, `guide`,  is added, which attaches to each controller entity.
- Each time a new frame is rendered, the `guide` components calculates the appropriate haptic feedback for each controller based on the distance between each and the closest data point.
- As a controller nears a data point, the haptic intensity increases.
- This increase in intensity is based on a mapping from the controller's proximity to the point, to two quadratic functions: one which determines intensity growth at long range, and another that introduces rapid growth at near proximity. This combination method was based on a drop of in precision of users ability to perceive differences at high vibration intensities.  
- Once contact is made with a data point, the controller vibrations switch to interval pulses to indicate that a point is being touched.
- Two custom type interfaces are also included for the component and its state property: `Guidance` and `State`
- Testing for each case of haptic behavior is included.

Sound:
- A check is added to stop a sound if it is currently playing when triggered, allowing sounds to be restarted mid play through.
- This allows sounds to be played repeatedly when a single data point is collided with multiple times in quick succession.
- Which means you can play the graph like an instrument! 


Note: This update is focused on interface design, and implements a naive, memory intensive method of nearest data point selection. This can cause lag when large datasets are introduced. The following update will focus on improving the efficiency of this selection using the kd tree data structure.